### PR TITLE
Remove msgTask struct

### DIFF
--- a/consensus.go
+++ b/consensus.go
@@ -705,13 +705,13 @@ func (p *Pbft) getNextMessage(span trace.Span, timeout time.Duration) (*MessageR
 		msg, discards := p.msgQueue.readMessageWithDiscards(p.getState(), p.state.view)
 		// send the discard messages
 		for _, msg := range discards {
-			spanAddEventMessage("dropMessage", span, msg.obj)
+			spanAddEventMessage("dropMessage", span, msg)
 		}
 		if msg != nil {
 			// add the event to the span
-			spanAddEventMessage("message", span, msg.obj)
+			spanAddEventMessage("message", span, msg)
 
-			return msg.obj, true
+			return msg, true
 		}
 
 		if p.forceTimeoutCh {
@@ -738,12 +738,7 @@ func (p *Pbft) PushMessage(msg *MessageReq) {
 
 // pushMessage pushes a new message to the message queue
 func (p *Pbft) pushMessage(msg *MessageReq) {
-	task := &msgTask{
-		view: msg.View,
-		msg:  msg.Type,
-		obj:  msg,
-	}
-	p.msgQueue.pushMessage(task)
+	p.msgQueue.pushMessage(msg)
 
 	select {
 	case p.updateCh <- struct{}{}:

--- a/msg_queue_test.go
+++ b/msg_queue_test.go
@@ -6,14 +6,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func mockQueueMsg(id string, state MsgType, view *View) *msgTask {
-	return &msgTask{
-		view: view,
-		msg:  state,
-		obj: &MessageReq{
-			// use the from field to identify the msg
-			From: NodeID(id),
-		},
+func mockQueueMsg(id string, msgType MsgType, view *View) *MessageReq {
+	return &MessageReq{
+		// use the from field to identify the msg
+		From: NodeID(id),
+		View: view,
+		Type: msgType,
 	}
 }
 
@@ -46,11 +44,11 @@ func TestMsgQueue_RoundChangeState(t *testing.T) {
 
 		msg1 := m.readMessage(RoundChangeState, ViewMsg(2, 0))
 		assert.NotNil(t, msg1)
-		assert.Equal(t, msg1.obj.From, NodeID("F"))
+		assert.Equal(t, msg1.From, NodeID("F"))
 
 		msg2 := m.readMessage(RoundChangeState, ViewMsg(2, 0))
 		assert.NotNil(t, msg2)
-		assert.Equal(t, msg2.obj.From, NodeID("D"))
+		assert.Equal(t, msg2.From, NodeID("D"))
 	}
 }
 


### PR DESCRIPTION
`msgTask` struct is redundant and is removed. Instead of it, existing `MessageReq` struct is used.