### PR TITLE
POS-150: Timeout calculation mocking mechanism

### DIFF
--- a/consensus_test.go
+++ b/consensus_test.go
@@ -666,8 +666,7 @@ func TestExponentialTimeout(t *testing.T) {
 		tc := tc // rebind tc into this lexical scope
 		t.Run(tc.description, func(t *testing.T) {
 			t.Parallel()
-			p := Pbft{state: &currentState{view: &View{Round: tc.round}}}
-			timeout := p.exponentialTimeout()
+			timeout := exponentialTimeout(tc.round)
 			require.Equal(t, tc.expected, timeout, fmt.Sprintf("timeout should be %s", tc.expected))
 		})
 	}
@@ -828,7 +827,8 @@ func newMockPbft(t *testing.T, accounts []string, account string, backendArg ...
 
 	// initialize pbft
 	m.Pbft = New(acct, m,
-		WithLogger(log.New(loggerOutput, "", log.LstdFlags)))
+		WithLogger(log.New(loggerOutput, "", log.LstdFlags)),
+		WithRoundTimeout(func(u uint64) time.Duration { return time.Millisecond }))
 
 	// initialize backend mock
 	var backend *mockBackend


### PR DESCRIPTION
Consensus algorithm unit tests which either haven't seeded any messages to message queues or seeded future messages, lasted too long (3s each, which is timeout for default round 0). Those unit tests are: `TestTransition_AcceptState_NonProposer_Cancellation`, `TestTransition_ValidateState_MoveToRoundChangeState` and `TestTransition_ValidateState_DiscardMessage`

Mocking timeout calculation consists of adding delegate for timeout calculation to Pbft struct and setting it to some arbitrary small value (e.g. 1 ms) within the `mockPbft`.

This PR is dependent upon [POS-147 PR](https://github.com/0xPolygon/pbft-consensus/pull/15). I am going to rebase this branch to the main branch after [POS-147 PR](https://github.com/0xPolygon/pbft-consensus/pull/15) gets merged to it, in order to include only single commit made by this proposal.