### PR TITLE
Add Init to Backend

### DIFF
--- a/consensus.go
+++ b/consensus.go
@@ -113,8 +113,8 @@ type Backend interface {
 	// Hash hashes the proposal bytes
 	Hash(p []byte) []byte
 
-	// Reset is used to signal the backend that the round is changing
-	Reset()
+	// Init is used to signal the backend that a new round is going to start.
+	Init()
 
 	// IsStuck returns whether the pbft is stucked
 	IsStuck(num uint64) (uint64, bool)
@@ -271,6 +271,8 @@ func (p *Pbft) runAcceptState(ctx context.Context) { // start new round
 		p.setState(SyncState)
 		return
 	}
+
+	p.backend.Init()
 
 	// reset round messages
 	p.state.resetRoundMsgs()
@@ -522,8 +524,6 @@ func (p *Pbft) handleStateErr(err error) {
 }
 
 func (p *Pbft) runRoundChangeState(ctx context.Context) {
-	p.backend.Reset()
-
 	ctx, span := p.tracer.Start(ctx, "RoundChange")
 	defer span.End()
 

--- a/consensus.go
+++ b/consensus.go
@@ -113,6 +113,9 @@ type Backend interface {
 	// Hash hashes the proposal bytes
 	Hash(p []byte) []byte
 
+	// Reset is used to signal the backend that the round is changing
+	Reset()
+
 	// IsStuck returns whether the pbft is stucked
 	IsStuck(num uint64) (uint64, bool)
 }
@@ -519,6 +522,8 @@ func (p *Pbft) handleStateErr(err error) {
 }
 
 func (p *Pbft) runRoundChangeState(ctx context.Context) {
+	p.backend.Reset()
+
 	ctx, span := p.tracer.Start(ctx, "RoundChange")
 	defer span.End()
 

--- a/consensus_test.go
+++ b/consensus_test.go
@@ -994,5 +994,5 @@ func (m *mockBackend) ValidatorSet() ValidatorSet {
 	return m.validators
 }
 
-func (m *mockBackend) Reset() {
+func (m *mockBackend) Init() {
 }

--- a/consensus_test.go
+++ b/consensus_test.go
@@ -993,3 +993,6 @@ func (m *mockBackend) Insert(pp *SealedProposal) error {
 func (m *mockBackend) ValidatorSet() ValidatorSet {
 	return m.validators
 }
+
+func (m *mockBackend) Reset() {
+}

--- a/e2e/framework.go
+++ b/e2e/framework.go
@@ -462,7 +462,7 @@ func (f *fsm) Hash(p []byte) []byte {
 	return h.Sum(nil)
 }
 
-func (f *fsm) Reset() {
+func (f *fsm) Init() {
 }
 
 type valString struct {

--- a/e2e/framework.go
+++ b/e2e/framework.go
@@ -462,6 +462,9 @@ func (f *fsm) Hash(p []byte) []byte {
 	return h.Sum(nil)
 }
 
+func (f *fsm) Reset() {
+}
+
 type valString struct {
 	nodes        []pbft.NodeID
 	lastProposer pbft.NodeID


### PR DESCRIPTION
There is a likely scenario I am facing in which the `Backend` implementation stores locally some data about the current round in order to be reused between different stages of the Pbft cycle. For example, a Proposer can pre-compute all the state transition in the `Validate()` callback (`Accept` state) and only do a small canonical head change upon `Commit()`. This is not possible if we do not store some information on the Backend. However, that is not safe right now since a Round change might provoke that the data is not valid anymore.

This PR adds a new function to the `Backend` called `Init()`. This function is called every time that the `Accept` state is reached. During that function, the `Backend` should restart and flush any old data from its state from a previous round and this height (if any).

An alternative to this PR would be to do a `Reset()` function called whenever there is a round state change. However, this would not be called during the first iteration of the protocol and then it would be up to `BuildProposal()` and `Validate()` to run the same script to initialize the state. With `Init()` we get both things, a single entrypoint to initialize the state and to reset it.