### PR TITLE
Add String() to View

### DIFF
--- a/state.go
+++ b/state.go
@@ -84,7 +84,7 @@ func (v *View) Copy() *View {
 }
 
 func (v *View) String() string {
-	return fmt.Sprintf("(%d, %d)", v.Sequence, v.Round)
+	return fmt.Sprintf("(Sequence=%d, Round=%d)", v.Sequence, v.Round)
 }
 
 func ViewMsg(sequence, round uint64) *View {

--- a/state.go
+++ b/state.go
@@ -83,6 +83,10 @@ func (v *View) Copy() *View {
 	return vv
 }
 
+func (v *View) String() string {
+	return fmt.Sprintf("(%d, %d)", v.Sequence, v.Round)
+}
+
 func ViewMsg(sequence, round uint64) *View {
 	return &View{
 		Round:    round,


### PR DESCRIPTION
When I print the `View` struct with the `fmt` library due to the `Round` field being before the `Sequence` field it shows as (Round, Sequence) on the screen which is confusing. Instead of changing the order of the fields, this PR implements the `String()` method directly.