### PR TITLE
POS-58 Implement liveness issue test proof

### DIFF
--- a/consensus.go
+++ b/consensus.go
@@ -184,6 +184,14 @@ func New(validator SignKey, transport Transport, opts ...ConfigOption) *Pbft {
 	return p
 }
 
+func (p *Pbft) IsStateLocked() bool {
+	return p.state.IsLocked()
+}
+
+func (p *Pbft) Proposal() *Proposal {
+	return p.state.proposal
+}
+
 func (p *Pbft) SetBackend(backend Backend) error {
 	p.backend = backend
 

--- a/consensus.go
+++ b/consensus.go
@@ -188,7 +188,7 @@ func (p *Pbft) IsStateLocked() bool {
 	return p.state.IsLocked()
 }
 
-func (p *Pbft) Proposal() *Proposal {
+func (p *Pbft) GetProposal() *Proposal {
 	return p.state.proposal
 }
 

--- a/e2e/framework.go
+++ b/e2e/framework.go
@@ -104,7 +104,7 @@ func (c *cluster) syncWithNetwork(ourselves string) (uint64, []*pbft.SealedPropo
 		if c.hook != nil {
 			// we need to see if this transport does allow those two nodes to be connected
 			// Otherwise, that node should not be elegible to sync
-			if !c.hook.Connects(pbft.NodeID(ourselves), pbft.NodeID(n.name)) {
+			if !c.hook.ShouldConnect(pbft.NodeID(ourselves), pbft.NodeID(n.name)) {
 				continue
 			}
 		}
@@ -406,6 +406,8 @@ func (k key) Sign(b []byte) ([]byte, error) {
 
 // -- fsm --
 
+const ProposalLength = 8
+
 type fsm struct {
 	n               *node
 	nodes           []string
@@ -424,17 +426,13 @@ func (f *fsm) IsStuck(num uint64) (uint64, bool) {
 
 func (f *fsm) BuildProposal() (*pbft.Proposal, error) {
 	// make different proposal for each sequence/round
-	prop := make([]byte, 8)
+	prop := make([]byte, ProposalLength)
 	_, _ = rand.Read(prop)
 	proposal := &pbft.Proposal{
 		Data: prop,
 		Time: time.Now().Add(1 * time.Second),
 	}
 	return proposal, nil
-}
-
-func (f *fsm) setValidationFails(v bool) {
-	f.validationFails = v
 }
 
 func (f *fsm) Validate(proposal []byte) error {

--- a/e2e/framework.go
+++ b/e2e/framework.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"math/rand"
 	"os"
 	"sync"
 	"testing"
@@ -422,8 +423,11 @@ func (f *fsm) IsStuck(num uint64) (uint64, bool) {
 }
 
 func (f *fsm) BuildProposal() (*pbft.Proposal, error) {
+	// make different proposal for each sequence/round
+	prop := make([]byte, 8)
+	_, _ = rand.Read(prop)
 	proposal := &pbft.Proposal{
-		Data: []byte{byte(f.Height())},
+		Data: prop,
 		Time: time.Now().Add(1 * time.Second),
 	}
 	return proposal, nil
@@ -483,6 +487,7 @@ func (v *valString) CalcProposer(round uint64) pbft.NodeID {
 	}
 
 	pick := seed % uint64(v.Len())
+
 	return (v.nodes)[pick]
 }
 

--- a/e2e/framework.go
+++ b/e2e/framework.go
@@ -104,7 +104,7 @@ func (c *cluster) syncWithNetwork(ourselves string) (uint64, []*pbft.SealedPropo
 		if c.hook != nil {
 			// we need to see if this transport does allow those two nodes to be connected
 			// Otherwise, that node should not be elegible to sync
-			if !c.hook.ShouldConnect(pbft.NodeID(ourselves), pbft.NodeID(n.name)) {
+			if !c.hook.Connects(pbft.NodeID(ourselves), pbft.NodeID(n.name)) {
 				continue
 			}
 		}
@@ -406,8 +406,6 @@ func (k key) Sign(b []byte) ([]byte, error) {
 
 // -- fsm --
 
-const ProposalLength = 8
-
 type fsm struct {
 	n               *node
 	nodes           []string
@@ -426,7 +424,7 @@ func (f *fsm) IsStuck(num uint64) (uint64, bool) {
 
 func (f *fsm) BuildProposal() (*pbft.Proposal, error) {
 	// make different proposal for each sequence/round
-	prop := make([]byte, ProposalLength)
+	prop := make([]byte, 8)
 	_, _ = rand.Read(prop)
 	proposal := &pbft.Proposal{
 		Data: prop,

--- a/state.go
+++ b/state.go
@@ -172,6 +172,10 @@ func newState() *currentState {
 	return c
 }
 
+func (c *currentState) IsLocked() bool {
+	return c.locked
+}
+
 func (c *currentState) GetSequence() uint64 {
 	return c.view.Sequence
 }


### PR DESCRIPTION
PR is follow up of stale PR https://github.com/0xPolygon/pbft-consensus/pull/19

This PR implements integration test that proves that PolyBFT consensus algorithm (inspired by IBFT) has liveness issues. Test is currently deliberately failing, because it expects that there are no errors, however timeout error is triggered by test framework since no consensus is reached after predefined time.

Test is implemented by having a scenario, discussed in [Correctness Analysis of Istanbul Byzantine Fault Tolerance paper, Chapter 7.1, Case 1](https://arxiv.org/pdf/1901.07160.pdf) on mind:
Note: for simplicity, imagine that we have validator set which has 5 validators {a1, a2, a3, a4 and a5}. Validator nodes are not named exactly this way within the test, but the point is there.

- a3 is proposer and proposes block B (sends PREPARE and PRE-PREPARE messages),
- a1 and a2 receive PRE-PREPARE from all the validator nodes and send PREPARE messages. a3, a4 and a5 don't receive either message (e.g. transient network issues),
- a1 and a2 locked on proposal B, since they have received enough PREPARE messages (2*F+1, where F is number of max faulty nodes),
- since there are only PREPARE messages from a1 and a2 and no COMMIT messages, when timeout elapses, all the nodes move to ROUND CHANGE state,
- when they eventually gossip enough ROUND CHANGE messages, they agree upon moving to the next round where a new proposer (e.g. a4) gets calculated,
- a4 proposes new proposal B' which is different from the one a1 and a2 got locked on,
- a3, a4 and a5 all respond with PREPARE message and lock on B' proposal (whereas a1 and a2 respond with ROUND CHANGE, since they are already locked on proposal B),
- before responding with COMMIT messages, some of those nodes becomes faulty (e.g. a3) and only a4 and a5 are able to send COMMIT messages. So we don't have enough COMMIT messages in order to move to COMMIT state (and eventually make a final proposal).

We have situation where a1 and a2 make partition 1 (locked on proposal B) and a3 and a5 (locked on proposal B'). The faulty a4 node is lacking in order to have quorum.