### PR TITLE
Decouple MaxFaultyNodes and QuorumSize calculations from currentState struct

### DIFF
--- a/consensus.go
+++ b/consensus.go
@@ -762,3 +762,21 @@ func exponentialTimeout(round uint64) time.Duration {
 	}
 	return timeout
 }
+
+// Calculate max faulty nodes in order to have Byzantine-fault tollerant system.
+// Formula explanation:
+// N -> number of nodes in PBFT
+// F -> number of faulty nodes
+// N = 3 * F + 1 => F = (N - 1) / 3
+
+// PBFT tolerates 1 failure with 4 nodes
+// 4 = 3 * 1 + 1
+// To tolerate 2 failures, PBFT requires 7 nodes
+// 7 = 3 * 2 + 1
+// It should always take the floor of the result
+func MaxFaultyNodes(nodesCount int) int {
+	if nodesCount <= 0 {
+		return 0
+	}
+	return (nodesCount - 1) / 3
+}

--- a/consensus.go
+++ b/consensus.go
@@ -780,3 +780,10 @@ func MaxFaultyNodes(nodesCount int) int {
 	}
 	return (nodesCount - 1) / 3
 }
+
+// Calculates quorum size (namely the number of required messages of some type in order to proceed to the next state in PolyBFT state machine).
+// It is calculated by formula:
+// 2 * F + 1, where F denotes maximum count of faulty nodes in order to have Byzantine fault tollerant property satisfied.
+func QuorumSize(nodesCount int) int {
+	return 2*MaxFaultyNodes(nodesCount) + 1
+}

--- a/state.go
+++ b/state.go
@@ -208,7 +208,7 @@ func (c *currentState) NumValid() int {
 	// 2 * F + 1
 	// + 1 is up to the caller to add
 	// the current node tallying the messages will include its own message
-	return 2 * c.MaxFaultyNodes()
+	return QuorumSize(c.validators.Len()) - 1
 }
 
 // getErr returns the current error, if any, and consumes it

--- a/state.go
+++ b/state.go
@@ -198,18 +198,9 @@ func (c *currentState) setState(s PbftState) {
 	atomic.StoreUint64(stateAddr, uint64(s))
 }
 
-// MaxFaultyNodes returns the maximum number of allowed faulty nodes (F), based on the current validator set
+// MaxFaultyNodes returns the maximum number of allowed faulty nodes (F), based on the current validator set size
 func (c *currentState) MaxFaultyNodes() int {
-	// N -> number of nodes in PBFT
-	// F -> number of faulty nodes
-	// N = 3 * F + 1 => F = (N - 1) / 3
-	//
-	// PBFT tolerates 1 failure with 4 nodes
-	// 4 = 3 * 1 + 1
-	// To tolerate 2 failures, PBFT requires 7 nodes
-	// 7 = 3 * 2 + 1
-	// It should always take the floor of the result
-	return (c.validators.Len() - 1) / 3
+	return MaxFaultyNodes(c.validators.Len())
 }
 
 // NumValid returns the number of required messages

--- a/state_test.go
+++ b/state_test.go
@@ -52,6 +52,7 @@ func TestState_FaultyNodesCount(t *testing.T) {
 	cases := []struct {
 		TotalNodesCount, FaultyNodesCount int
 	}{
+		{0, 0},
 		{1, 0},
 		{2, 0},
 		{3, 0},

--- a/state_test.go
+++ b/state_test.go
@@ -74,6 +74,28 @@ func TestState_FaultyNodesCount(t *testing.T) {
 	}
 }
 
+func Test_QuorumSize(t *testing.T) {
+	cases := []struct {
+		TotalNodesCount, QuorumSize int
+	}{
+		{1, 1},
+		{2, 1},
+		{3, 1},
+		{4, 3},
+		{5, 3},
+		{6, 3},
+		{7, 5},
+		{8, 5},
+		{9, 5},
+		{10, 7},
+		{100, 67},
+	}
+
+	for _, c := range cases {
+		assert.Equal(t, c.QuorumSize, QuorumSize(c.TotalNodesCount))
+	}
+}
+
 func TestState_ValidNodesCount(t *testing.T) {
 	cases := []struct {
 		TotalNodesCount, ValidNodesCount int

--- a/state_test.go
+++ b/state_test.go
@@ -70,7 +70,7 @@ func TestState_FaultyNodesCount(t *testing.T) {
 		s := newState()
 		s.validators = convertToMockValidatorSet(generateValidatorNodes(c.TotalNodesCount, "validator"))
 
-		assert.Equal(t, s.MaxFaultyNodes(), c.FaultyNodesCount)
+		assert.Equal(t, c.FaultyNodesCount, s.MaxFaultyNodes())
 	}
 }
 
@@ -116,7 +116,7 @@ func TestState_ValidNodesCount(t *testing.T) {
 		s := newState()
 		s.validators = convertToMockValidatorSet(generateValidatorNodes(c.TotalNodesCount, "validator"))
 
-		assert.Equal(t, s.NumValid(), c.ValidNodesCount)
+		assert.Equal(t, c.ValidNodesCount, s.NumValid())
 	}
 }
 
@@ -139,14 +139,14 @@ func TestState_AddMessages(t *testing.T) {
 	s.addMessage(pool.createMessage("B", MessageReq_Commit))
 	s.addMessage(pool.createMessage("B", MessageReq_Commit))
 
-	assert.Equal(t, s.numCommitted(), 2)
+	assert.Equal(t, 2, s.numCommitted())
 
 	// -- test prepare messages --
 	s.addMessage(pool.createMessage("C", MessageReq_Prepare))
 	s.addMessage(pool.createMessage("C", MessageReq_Prepare))
 	s.addMessage(pool.createMessage("D", MessageReq_Prepare))
 
-	assert.Equal(t, s.numPrepared(), 2)
+	assert.Equal(t, 2, s.numPrepared())
 
 	// -- test round change messages --
 	rounds := 2


### PR DESCRIPTION
#### Max faulty nodes calculation
When working on fuzz framework, it was realized that `MaxFaultyNodes` calculation is needed there as well, so this PR decouples the calculation from the `currentState` struct, by making it available on the package-level in order to be able to reuse it, without code duplication.

#### Quorum size calculation
As mentioned in comment https://github.com/0xPolygon/pbft-consensus/pull/23#issuecomment-1034972046, additional package-level function is introduced called `QuorumSize`. It determines minimum number of messages needed upon agreement when moving from one to another `PbftState` within the state machine.