### PR TITLE
Feat/validate proposal

### DIFF
--- a/consensus_test.go
+++ b/consensus_test.go
@@ -18,8 +18,11 @@ import (
 )
 
 var (
-	mockProposal  = []byte{0x1, 0x2, 0x3}
+	mockProposal = []byte{0x1, 0x2, 0x3}
+	digest       = []byte{0x1}
+
 	mockProposal1 = []byte{0x1, 0x2, 0x3, 0x4}
+	digest1       = []byte{0x2}
 )
 
 func TestTransition_AcceptState_ToSyncState(t *testing.T) {
@@ -70,6 +73,7 @@ func TestTransition_AcceptState_Proposer_Locked(t *testing.T) {
 	i.state.locked = true
 	i.state.proposal = &Proposal{
 		Data: mockProposal,
+		Hash: digest,
 	}
 
 	i.runCycle(context.Background())
@@ -228,6 +232,7 @@ func TestTransition_AcceptState_Validator_LockWrong(t *testing.T) {
 	// locked proposal
 	i.state.proposal = &Proposal{
 		Data: mockProposal,
+		Hash: digest,
 	}
 	i.state.lock()
 
@@ -236,6 +241,7 @@ func TestTransition_AcceptState_Validator_LockWrong(t *testing.T) {
 		From:     "A",
 		Type:     MessageReq_Preprepare,
 		Proposal: mockProposal1,
+		Hash:     digest1,
 		View:     ViewMsg(1, 0),
 	})
 
@@ -257,7 +263,10 @@ func TestTransition_AcceptState_Validator_LockCorrect(t *testing.T) {
 	// locked proposal
 	proposal := mockProposal
 
-	i.state.proposal = &Proposal{Data: proposal}
+	i.state.proposal = &Proposal{
+		Data: proposal,
+		Hash: digest,
+	}
 	i.state.locked = true
 
 	i.emitMsg(&MessageReq{
@@ -289,11 +298,6 @@ func TestTransition_AcceptState_Validate_ProposalFail(t *testing.T) {
 	m := newMockPbft(t, validatorIds, "C", backend)
 	m.state.view = ViewMsg(1, 0)
 	m.setState(AcceptState)
-
-	m.setProposal(&Proposal{
-		Data: mockProposal,
-		Time: time.Now(),
-	})
 
 	// Prepare messages
 	m.emitMsg(&MessageReq{
@@ -504,10 +508,6 @@ func TestTransition_ValidateState_MoveToCommitState(t *testing.T) {
 	// we receive enough prepare messages to lock and commit the proposal
 	m := newMockPbft(t, []string{"A", "B", "C", "D"}, "A")
 	m.setState(ValidateState)
-	m.setProposal(&Proposal{
-		Data: mockProposal,
-		Time: time.Now().Add(1 * time.Second),
-	})
 
 	// Prepare messages
 	m.emitMsg(&MessageReq{
@@ -576,6 +576,7 @@ func TestTransition_ValidateState_WrongMessageType(t *testing.T) {
 		From:     "A",
 		Type:     MessageReq_Preprepare,
 		Proposal: mockProposal,
+		Hash:     digest,
 		View:     ViewMsg(1, 0),
 	}
 	heap.Push(&m.msgQueue.validateStateQueue, msg)
@@ -586,10 +587,6 @@ func TestTransition_ValidateState_WrongMessageType(t *testing.T) {
 func TestTransition_ValidateState_DiscardMessage(t *testing.T) {
 	m := newMockPbft(t, []string{"A", "B"}, "A")
 	m.setState(ValidateState)
-	m.setProposal(&Proposal{
-		Data: mockProposal,
-		Time: time.Now().Add(1 * time.Second),
-	})
 	m.state.view = ViewMsg(1, 2)
 
 	// Send message from the past (it should be discarded)
@@ -775,18 +772,14 @@ type mockPbft struct {
 }
 
 func (m *mockPbft) emitMsg(msg *MessageReq) {
-	// convert the address from the address pool
-	// from := m.pool.get(string(msg.From)).Address()
-	// msg.From = from
-
+	if msg.Hash == nil {
+		// Use default safe value
+		msg.Hash = digest
+	}
 	m.Pbft.PushMessage(msg)
 }
 
 func (m *mockPbft) addMessage(msg *MessageReq) {
-	// convert the address from the address pool
-	// from := m.pool.get(string(msg.From)).Address()
-	// msg.From = from
-
 	m.state.addMessage(msg)
 }
 
@@ -843,6 +836,7 @@ func newMockPbft(t *testing.T, accounts []string, account string, backendArg ...
 	m.state.proposal = &Proposal{
 		Data: mockProposal,
 		Time: time.Now(),
+		Hash: digest,
 	}
 
 	ctx, cancelFn := context.WithCancel(context.Background())
@@ -870,6 +864,8 @@ func (m *mockPbft) Close() {
 	m.cancelFn()
 }
 
+// setProposal sets the proposal that will get returned if the pbft consensus
+// calls the backend 'BuildProposal' function.
 func (m *mockPbft) setProposal(p *Proposal) {
 	if p.Hash == nil {
 		h := sha1.New()

--- a/e2e/framework.go
+++ b/e2e/framework.go
@@ -426,6 +426,7 @@ func (f *fsm) BuildProposal() (*pbft.Proposal, error) {
 		Data: []byte{byte(f.Height())},
 		Time: time.Now().Add(1 * time.Second),
 	}
+	proposal.Hash = hash(proposal.Data)
 	return proposal, nil
 }
 
@@ -433,7 +434,7 @@ func (f *fsm) setValidationFails(v bool) {
 	f.validationFails = v
 }
 
-func (f *fsm) Validate(proposal []byte) error {
+func (f *fsm) Validate(proposal *pbft.Proposal) error {
 	if f.validationFails {
 		return fmt.Errorf("validation error")
 	}
@@ -456,7 +457,7 @@ func (f *fsm) ValidatorSet() pbft.ValidatorSet {
 	return &vv
 }
 
-func (f *fsm) Hash(p []byte) []byte {
+func hash(p []byte) []byte {
 	h := sha1.New()
 	h.Write(p)
 	return h.Sum(nil)

--- a/state.go
+++ b/state.go
@@ -1,6 +1,7 @@
 package pbft
 
 import (
+	"bytes"
 	"fmt"
 	"sync/atomic"
 	"time"
@@ -43,8 +44,8 @@ type MessageReq struct {
 	// view is the view assigned to the message
 	View *View
 
-	// hash of the locked proposal
-	Digest string
+	// hash of the proposal (only for prepare messages)
+	Hash []byte
 
 	// proposal is the arbitrary data proposal (only for preprepare messages)
 	Proposal []byte
@@ -129,6 +130,24 @@ type Proposal struct {
 
 	// Time is the time to create the proposal
 	Time time.Time
+
+	// Hash is the digest of the data to seal
+	Hash []byte
+}
+
+// Equal compares whether two proposals have the same hash
+func (p *Proposal) Equal(pp *Proposal) bool {
+	return bytes.Equal(p.Hash, pp.Hash)
+}
+
+// Copy makes a copy of the Proposal
+func (p *Proposal) Copy() *Proposal {
+	pp := new(Proposal)
+	*pp = *p
+
+	pp.Data = append([]byte{}, p.Data...)
+	pp.Hash = append([]byte{}, p.Hash...)
+	return pp
 }
 
 // currentState defines the current state object in PBFT

--- a/state.go
+++ b/state.go
@@ -44,11 +44,23 @@ type MessageReq struct {
 	// view is the view assigned to the message
 	View *View
 
-	// hash of the proposal (only for prepare messages)
+	// hash of the proposal
 	Hash []byte
 
 	// proposal is the arbitrary data proposal (only for preprepare messages)
 	Proposal []byte
+}
+
+func (m *MessageReq) Validate() error {
+	// Hash field has to exist for state != RoundStateChange
+	if m.Type != MessageReq_RoundChange {
+		if m.Hash == nil {
+			return fmt.Errorf("hash is empty for type %s", m.Type.String())
+		}
+	}
+
+	// TODO
+	return nil
 }
 
 func (m *MessageReq) SetProposal(proposal []byte) {


### PR DESCRIPTION
This PR does two things:
- It changes the Backend interface to remove the `Hash` function. Now, the Hash of the proposal is supplied during `BuildProposal` in case of a producer and it needs to get validated in `ValidateProposal` for a validator. This makes much more sense to me because before the hash felt like some transient data that was generated on the fly for specific purposes but now it is part of the state. Besides, we have much more flexibility on what that hash represents.
- Since the proposal hash is available on the state, we can ensure that only messages with the correct hash are being processed during Prepare and Commit stages.