### PR TITLE
Add validation for commit message

### DIFF
--- a/consensus.go
+++ b/consensus.go
@@ -118,6 +118,9 @@ type Backend interface {
 
 	// IsStuck returns whether the pbft is stucked
 	IsStuck(num uint64) (uint64, bool)
+
+	// ValidateCommit is used to validate that a given commit is valid
+	ValidateCommit(seal []byte) error
 }
 
 // Pbft represents the PBFT consensus mechanism object
@@ -423,6 +426,10 @@ func (p *Pbft) runValidateState(ctx context.Context) { // start new round
 			p.state.addPrepared(msg)
 
 		case MessageReq_Commit:
+			if err := p.backend.ValidateCommit(msg.Seal); err != nil {
+				p.logger.Printf("[ERROR]: failed to validate commit: %v", err)
+				continue
+			}
 			p.state.addCommitted(msg)
 
 		default:

--- a/consensus.go
+++ b/consensus.go
@@ -120,7 +120,7 @@ type Backend interface {
 	IsStuck(num uint64) (uint64, bool)
 
 	// ValidateCommit is used to validate that a given commit is valid
-	ValidateCommit(seal []byte) error
+	ValidateCommit(from NodeID, seal []byte) error
 }
 
 // Pbft represents the PBFT consensus mechanism object
@@ -426,7 +426,7 @@ func (p *Pbft) runValidateState(ctx context.Context) { // start new round
 			p.state.addPrepared(msg)
 
 		case MessageReq_Commit:
-			if err := p.backend.ValidateCommit(msg.Seal); err != nil {
+			if err := p.backend.ValidateCommit(msg.From, msg.Seal); err != nil {
 				p.logger.Printf("[ERROR]: failed to validate commit: %v", err)
 				continue
 			}

--- a/consensus_test.go
+++ b/consensus_test.go
@@ -947,7 +947,7 @@ func (m *mockBackend) HookIsStuckHandler(isStuck isStuckDelegate) *mockBackend {
 	return m
 }
 
-func (m *mockBackend) ValidateCommit(seal []byte) error {
+func (m *mockBackend) ValidateCommit(from NodeID, seal []byte) error {
 	return nil
 }
 

--- a/consensus_test.go
+++ b/consensus_test.go
@@ -947,6 +947,10 @@ func (m *mockBackend) HookIsStuckHandler(isStuck isStuckDelegate) *mockBackend {
 	return m
 }
 
+func (m *mockBackend) ValidateCommit(seal []byte) error {
+	return nil
+}
+
 func (m *mockBackend) Hash(p []byte) []byte {
 	h := sha1.New()
 	h.Write(p)

--- a/e2e/framework.go
+++ b/e2e/framework.go
@@ -465,7 +465,7 @@ func (f *fsm) Hash(p []byte) []byte {
 func (f *fsm) Init() {
 }
 
-func (f *fsm) ValidateCommit(seal []byte) error {
+func (f *fsm) ValidateCommit(node pbft.NodeID, seal []byte) error {
 	return nil
 }
 

--- a/e2e/framework.go
+++ b/e2e/framework.go
@@ -465,6 +465,10 @@ func (f *fsm) Hash(p []byte) []byte {
 func (f *fsm) Init() {
 }
 
+func (f *fsm) ValidateCommit(seal []byte) error {
+	return nil
+}
+
 type valString struct {
 	nodes        []pbft.NodeID
 	lastProposer pbft.NodeID


### PR DESCRIPTION
This PR is a design idea (not to be merged yet).

We should aim to validate as early as possible on the Pbft protocol. For example, instead of validating if the transactions in the block are valid just at the `Commit` phase right at the end, we can do it on the `Validation` stage. The same applies for commit seal messages, we can check them right when we receive them.

Ideally, the goal should be that `backend.Insert` does not have any situation to fail since everything that can spawn an error has been found beforehand.