### PR TITLE
Liveness fix (introduce relocking concept)

### DIFF
--- a/consensus_test.go
+++ b/consensus_test.go
@@ -72,7 +72,7 @@ func TestTransition_AcceptState_Proposer_Locked(t *testing.T) {
 	i := newMockPbft(t, []NodeID{"A", "B", "C", "D"}, nil, "A")
 	i.setState(AcceptState)
 
-	i.state.lock()
+	i.state.lock(0)
 	i.state.proposal = &Proposal{
 		Data: mockProposal,
 		Hash: digest,
@@ -194,7 +194,7 @@ func TestTransition_AcceptState_Validator_ProposerInvalid(t *testing.T) {
 func TestTransition_AcceptState_Validator_LockWrong(t *testing.T) {
 	// We are a validator and have a locked state in 'proposal1'.
 	// We receive an invalid proposal 'proposal2' with different data.
-	i := newMockPbft(t, []NodeID{"A", "B", "C"}, nil, "B")
+	i := newMockPbft(t, []NodeID{"A", "B", "C", "D", "E", "F"}, nil, "B")
 	i.state.view = ViewMsg(1, 0)
 	i.setState(AcceptState)
 
@@ -203,7 +203,8 @@ func TestTransition_AcceptState_Validator_LockWrong(t *testing.T) {
 		Data: mockProposal,
 		Hash: digest,
 	}
-	i.state.lock()
+
+	i.state.lock(0)
 
 	// emit the wrong locked proposal
 	msg := createMessage(NodeID("A"), MessageReq_Preprepare, ViewMsg(1, 0))
@@ -231,7 +232,7 @@ func TestTransition_AcceptState_Validator_LockCorrect(t *testing.T) {
 		Data: mockProposal,
 		Hash: digest,
 	}
-	i.state.lock()
+	i.state.lock(0)
 	i.emitMsg(createMessage(NodeID("A"), MessageReq_Preprepare, ViewMsg(1, 0)))
 
 	i.runCycle(context.Background())
@@ -949,7 +950,7 @@ func (m *mockPbft) expect(res expectResult) {
 		m.t.Fatalf("incorrect commit messages acccumulated voting power actual: %d, expected:%d", accumulatedVotingPower, res.commitMsgsVotingPower)
 	}
 	if m.state.IsLocked() != res.locked {
-		m.t.Fatalf("incorrect locked actual: %v, expected: %v", m.state.locked, res.locked)
+		m.t.Fatalf("incorrect locked actual: %v, expected: %v", m.state.IsLocked(), res.locked)
 	}
 	if size := len(m.respMsg); uint64(size) != res.outgoing {
 		m.t.Fatalf("incorrect outgoing messages actual: %v, expected: %v", size, res.outgoing)

--- a/e2e/e2e_partition_test.go
+++ b/e2e/e2e_partition_test.go
@@ -54,14 +54,15 @@ func TestE2E_Partition_LivenessIssue_Case1_FiveNodes_OneFaulty(t *testing.T) {
 	transport := transport.NewGenericGossip()
 	// If livenessGossipHandler returns false, message should not be transported.
 	livenessGossipHandler := func(senderId, receiverId pbft.NodeID, msg *pbft.MessageReq) bool {
+		if msg.View.Round <= 1 && msg.Type == pbft.MessageReq_Commit {
+			// Cut all the commit messages gossiping for round 0 and 1
+			return false
+		}
+
 		if msg.View.Round > 1 || msg.View.Sequence > 2 {
 			// Faulty node is unresponsive after round 1, and all the other nodes are gossiping all the messages.
 			return senderId != faultyNodeId && receiverId != faultyNodeId
 		} else {
-			if msg.View.Round <= 1 && msg.Type == pbft.MessageReq_Commit {
-				// Cut all the commit messages gossiping for round 0 and 1
-				return false
-			}
 			if msg.View.Round == 1 && senderId == faultyNodeId &&
 				(msg.Type == pbft.MessageReq_RoundChange || msg.Type == pbft.MessageReq_Commit) {
 				// Case where we are in round 1 and 2 different nodes will lock the proposal
@@ -85,7 +86,7 @@ func TestE2E_Partition_LivenessIssue_Case1_FiveNodes_OneFaulty(t *testing.T) {
 	c.Start()
 	defer c.Stop()
 
-	err := c.WaitForHeight(3, 1*time.Minute, []string{"A_0", "A_2", "A_3", "A_4"})
+	err := c.WaitForHeight(3, 5*time.Minute, []string{"A_0", "A_2", "A_3", "A_4"})
 
 	if err != nil {
 		// log to check what is the end state
@@ -99,8 +100,7 @@ func TestE2E_Partition_LivenessIssue_Case1_FiveNodes_OneFaulty(t *testing.T) {
 		}
 	}
 
-	// TODO: Temporary assertion until liveness issue is resolved (after fix is merged we need to revert back to assert.NoError(t, err))
-	assert.Error(t, err)
+	assert.NoError(t, err)
 }
 
 // Test proves existence of liveness issues which is described in
@@ -188,7 +188,7 @@ func TestE2E_Partition_LivenessIssue_Case2_SixNodes_OneFaulty(t *testing.T) {
 	c.Start()
 	defer c.Stop()
 
-	err := c.WaitForHeight(3, 1*time.Minute, []string{"A_0", "A_1", "A_3", "A_4", "A_5"})
+	err := c.WaitForHeight(3, 5*time.Minute, []string{"A_0", "A_1", "A_3", "A_4", "A_5"})
 
 	if err != nil {
 		// log to check what is the end state
@@ -202,8 +202,7 @@ func TestE2E_Partition_LivenessIssue_Case2_SixNodes_OneFaulty(t *testing.T) {
 		}
 	}
 
-	// TODO: Temporary assertion until liveness issue is resolved (after fix is merged we need to revert back to assert.NoError(t, err))
-	assert.Error(t, err)
+	assert.NoError(t, err)
 }
 
 // TestE2E_Network_Stuck_Locked_Node_Dropped is a test that creates a situation with no consensus

--- a/msg_queue.go
+++ b/msg_queue.go
@@ -2,6 +2,7 @@ package pbft
 
 import (
 	"container/heap"
+	"fmt"
 	"sync"
 )
 
@@ -92,6 +93,20 @@ func (m *msgQueue) getQueue(st State) *msgQueueImpl {
 	}
 }
 
+// iterator fetches corresponding message queue based on pbft state and invokes iteratorLocked method against it.
+func (m *msgQueue) iterator(pbftState State, iterateHandler func(*MessageReq)) error {
+	m.queueLock.Lock()
+	defer m.queueLock.Unlock()
+
+	queueImpl := m.getQueue(pbftState)
+	if queueImpl == nil {
+		return fmt.Errorf("failed to resolve message queue for %s message type", MessageReq_Commit)
+	}
+
+	queueImpl.iteratorLocked(iterateHandler)
+	return nil
+}
+
 // newMsgQueue creates a new message queue structure
 func newMsgQueue() *msgQueue {
 	return &msgQueue{
@@ -175,6 +190,16 @@ func (m *msgQueueImpl) Pop() interface{} {
 	old[n-1] = nil
 	*m = old[0 : n-1]
 	return item
+}
+
+// iteratorLocked is iterator with custom handler which contains some arbitrary logic.
+// It is assumed that method is invoked within the lock.
+func (m *msgQueueImpl) iteratorLocked(iterateHandler func(*MessageReq)) {
+	for _, msg := range *m {
+		if iterateHandler != nil {
+			iterateHandler(msg.Copy())
+		}
+	}
 }
 
 // cmpView compares two proto views.

--- a/state_test.go
+++ b/state_test.go
@@ -223,7 +223,8 @@ func TestState_Lock_Unlock(t *testing.T) {
 		Data: proposalData,
 		Time: time.Now(),
 	}
-	s.lock()
+
+	s.lock(0)
 	assert.True(t, s.IsLocked())
 	assert.NotNil(t, s.proposal)
 


### PR DESCRIPTION
This PR is solution proposal for liveness issue by introducing a re-locking concept.
Re-locking enables that node which has locked some proposal in some of the previous rounds, locks a new one if it witnesses enough (`2 * F`, where F denotes max count of faulty nodes in order to have Byzantine fault tolerant system) COMMIT messages from the most recent round, which have the same proposal as the one sent the current proposer via a PRE-PREPARE message. If that is the case, then validator node rejects its locked proposal and immediately locks the one from PRE-PREPARE messages and votes for it by sending COMMIT message.
In order to track a round when the given node is initially locked, a `lockedRound *uint64` field is introduced to the `state` struct. When `lockedRound` is set to `nil`, it denotes that no proposal is locked (yet).