### PR TITLE
POS-225 Liveness issue test case 2

### DIFF
--- a/consensus.go
+++ b/consensus.go
@@ -396,6 +396,7 @@ func (p *Pbft) runValidateState(ctx context.Context) { // start new round
 	sendCommit := func(span trace.Span) {
 		// at this point either we have enough prepare messages
 		// or commit messages so we can lock the proposal
+		fmt.Printf("Locked on round %v and node %v\n", p.state.view.Round, p.validator.NodeID())
 		p.state.lock()
 
 		if !hasCommitted {

--- a/e2e/transport.go
+++ b/e2e/transport.go
@@ -34,6 +34,7 @@ func (t *transport) Gossip(msg *pbft.MessageReq) error {
 				send = t.hook.Gossip(msg.From, to, msg)
 			}
 			if send {
+				// fmt.Printf("Sending message %v from Node %v to node %v\n", msg.Type, msg.From, to)
 				handler(msg)
 			}
 		}(to, handler)


### PR DESCRIPTION
This PR implements integration test that proves that PolyBFT consensus algorithm (inspired by IBFT) has liveness issues. Liveness is a property of consensus algorithm and it refers to the following definition: provided that a transaction is submitted to all honest validators, then the transaction will eventually be included in the distributed permissioned transaction ledger[1].
will eventually be included in the distributed permissioned transaction ledger.

Test is currently deliberately failing, because it expects that there are no errors, however timeout error is triggered by test framework since no consensus is reached after predefined time.

Test is implemented by having a scenario, discussed in [Correctness Analysis of Istanbul Byzantine Fault Tolerance paper, Chapter 7.1, Case 2](https://arxiv.org/pdf/1901.07160.pdf) on mind:
Note: for simplicity, imagine that we have validator set which has 6 validators {a0, a1, a2, a3, a4 and a5}. Validator nodes are not named exactly this way within the test, but the point is there.