### PR TITLE
Fuzz/pbft-log-to-files

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -17,6 +17,8 @@ $ docker run --net=host -v "${PWD}/otel-jaeger-config.yaml":/otel-local-config.y
 
 ## Tests
 
+To log output of nodes into files, set environment variable E2E_LOG_TO_FILES to true.
+
 ### TestE2E_NoIssue
 
 Simple cluster with 5 machines.

--- a/e2e/e2e_node_drop_test.go
+++ b/e2e/e2e_node_drop_test.go
@@ -8,7 +8,13 @@ import (
 )
 
 func TestE2E_NodeDrop(t *testing.T) {
-	c := NewPBFTCluster(t, "node_drop", "ptr", 5)
+	config := &ClusterConfig{
+		Count:  5,
+		Name:   "node_drop",
+		Prefix: "ptr",
+	}
+
+	c := NewPBFTCluster(t, config)
 	c.Start()
 	// wait for two heights and stop node 1
 	err := c.WaitForHeight(2, 1*time.Minute)

--- a/e2e/e2e_noissue_test.go
+++ b/e2e/e2e_noissue_test.go
@@ -8,7 +8,13 @@ import (
 )
 
 func TestE2E_NoIssue(t *testing.T) {
-	c := NewPBFTCluster(t, "noissue", "noissue", 5, newRandomTransport(300*time.Millisecond))
+	config := &ClusterConfig{
+		Count:  5,
+		Name:   "noissue",
+		Prefix: "noissue",
+	}
+
+	c := NewPBFTCluster(t, config, newRandomTransport(300*time.Millisecond))
 	c.Start()
 	defer c.Stop()
 

--- a/e2e/e2e_partition_test.go
+++ b/e2e/e2e_partition_test.go
@@ -13,7 +13,13 @@ func TestE2E_Partition_OneMajority(t *testing.T) {
 	const nodesCnt = 5
 	hook := newPartitionTransport(300 * time.Millisecond)
 
-	c := NewPBFTCluster(t, "majority_partition", "prt", nodesCnt, hook)
+	config := &ClusterConfig{
+		Count:  nodesCnt,
+		Name:   "majority_partition",
+		Prefix: "prt",
+	}
+
+	c := NewPBFTCluster(t, config, hook)
 	c.Start()
 	defer c.Stop()
 
@@ -48,7 +54,13 @@ func TestE2E_Partition_MajorityCanValidate(t *testing.T) {
 	const nodesCnt = 7 // N=3F + 1, F = 2
 	hook := newPartitionTransport(300 * time.Millisecond)
 
-	c := NewPBFTCluster(t, "majority_partition", "prt", nodesCnt, hook)
+	config := &ClusterConfig{
+		Count:  nodesCnt,
+		Name:   "majority_partition",
+		Prefix: "prt",
+	}
+
+	c := NewPBFTCluster(t, config, hook)
 	limit := int(math.Floor(nodesCnt*2.0/3.0)) + 1 // 2F+1 nodes can Validate
 	for _, node := range c.Nodes() {
 		node.setFaultyNode(node.name >= "prt_"+strconv.Itoa(limit))
@@ -72,7 +84,13 @@ func TestE2E_Partition_MajorityCantValidate(t *testing.T) {
 	const nodesCnt = 7 // N=3F + 1, F = 2
 	hook := newPartitionTransport(300 * time.Millisecond)
 
-	c := NewPBFTCluster(t, "majority_partition", "prt", nodesCnt, hook)
+	config := &ClusterConfig{
+		Count:  nodesCnt,
+		Name:   "majority_partition",
+		Prefix: "prt",
+	}
+
+	c := NewPBFTCluster(t, config, hook)
 	limit := int(math.Floor(nodesCnt * 2.0 / 3.0)) // + 1 removed because 2F+1 nodes is majority
 	for _, node := range c.Nodes() {
 		node.setFaultyNode(node.name < "prt_"+strconv.Itoa(limit))
@@ -88,7 +106,13 @@ func TestE2E_Partition_BigMajorityCantValidate(t *testing.T) {
 	const nodesCnt = 100
 	hook := newPartitionTransport(300 * time.Millisecond)
 
-	c := NewPBFTCluster(t, "majority_partition", "prt", nodesCnt, hook)
+	config := &ClusterConfig{
+		Count:  nodesCnt,
+		Name:   "majority_partition",
+		Prefix: "prt",
+	}
+
+	c := NewPBFTCluster(t, config, hook)
 	limit := int(math.Floor(nodesCnt * 2.0 / 3.0)) // + 1 removed because 2F+1 nodes is majority
 	for _, node := range c.Nodes() {
 		node.setFaultyNode(node.name <= "prt_"+strconv.Itoa(limit))

--- a/e2e/fuzz/runner.go
+++ b/e2e/fuzz/runner.go
@@ -21,9 +21,15 @@ type Runner struct {
 }
 
 func NewRunner(initialNodesCount uint) *Runner {
+	config := &e2e.ClusterConfig{
+		Count:  int(initialNodesCount),
+		Name:   "fuzz_cluster",
+		Prefix: "NODE",
+	}
+
 	return &Runner{
 		availableActions: getAvailableActions(),
-		cluster:          e2e.NewPBFTCluster(nil, "fuzz_cluster", "NODE", int(initialNodesCount)),
+		cluster:          e2e.NewPBFTCluster(nil, config),
 		wg:               sync.WaitGroup{},
 	}
 }

--- a/e2e/fuzz_network_churn_test.go
+++ b/e2e/fuzz_network_churn_test.go
@@ -16,7 +16,13 @@ func TestFuzz_NetworkChurn(t *testing.T) {
 	nodeCount := 20
 	maxFaulty := nodeCount/3 - 1
 	const prefix = "ptr_"
-	c := NewPBFTCluster(t, "network_churn", "ptr", nodeCount)
+	config := &ClusterConfig{
+		Count:  nodeCount,
+		Name:   "network_churn",
+		Prefix: "ptr",
+	}
+
+	c := NewPBFTCluster(t, config)
 	c.Start()
 	defer c.Stop()
 	runningNodeCount := nodeCount

--- a/e2e/fuzz_unreliable_network_test.go
+++ b/e2e/fuzz_unreliable_network_test.go
@@ -19,7 +19,14 @@ func TestFuzz_Unreliable_Network(t *testing.T) {
 	currentHeight := uint64(0)
 	jitterMax := 500 * time.Millisecond
 	hook := newPartitionTransport(jitterMax)
-	c := NewPBFTCluster(t, "network_unreliable", "prt", nodesCount, hook)
+
+	config := &ClusterConfig{
+		Count:  nodesCount,
+		Name:   "network_unreliable",
+		Prefix: "prt",
+	}
+
+	c := NewPBFTCluster(t, config, hook)
 	t.Logf("Starting cluster with %d nodes, max faulty %d.\n", nodesCount, maxFaulty)
 	c.Start()
 	defer c.Stop()

--- a/e2e/helper.go
+++ b/e2e/helper.go
@@ -69,3 +69,21 @@ func isFuzzEnabled(t *testing.T) {
 		t.Skip("Fuzz tests are disabled.")
 	}
 }
+
+func CreateLogsDir(t *testing.T) (string, error) {
+	//logs directory will be generated at the root of the e2e project
+	var logsDir, logsDirName string
+	var err error
+
+	if t != nil {
+		logsDirName = t.Name()
+	} else {
+		logsDirName = "logs"
+	}
+
+	if os.Getenv("E2E_LOG_TO_FILES") == "true" {
+		logsDir, err = os.MkdirTemp("../", logsDirName+"-")
+	}
+
+	return logsDir, err
+}


### PR DESCRIPTION
Implemented a way to log node output to files instead of standard output.
To log into files instead of standard output, **E2E_LOG_TO_FILES** environment variable must be set to **true**.

On the cluster creation, based on the **E2E_LOG_TO_FILES** environment variable, a new directory in the e2e package root folder will be created, and each node will redirect its output to the file writer, or (if the variable is false) each node will redirect its output to the Stdout.

Each node will create its own .log file where the name of the file is the name of the node. Directory where the log files will be stored is named after the test which is currently running ('"testName-" + random string), or if no test is running (case when runner is started in the main function), directory name will be "logs-" + random string.

Directory for log files is created on new cluster creation and its full path is passed to each new node so that they can create their .log files in the appropriate directory.