### PR TITLE
Add info to Init

### DIFF
--- a/consensus_test.go
+++ b/consensus_test.go
@@ -994,5 +994,5 @@ func (m *mockBackend) ValidatorSet() ValidatorSet {
 	return m.validators
 }
 
-func (m *mockBackend) Init() {
+func (m *mockBackend) Init(*RoundInfo) {
 }

--- a/e2e/framework.go
+++ b/e2e/framework.go
@@ -462,7 +462,7 @@ func (f *fsm) Hash(p []byte) []byte {
 	return h.Sum(nil)
 }
 
-func (f *fsm) Init() {
+func (f *fsm) Init(*pbft.RoundInfo) {
 }
 
 type valString struct {


### PR DESCRIPTION
In #18, an `Init` function was introduced to signal when a new round was starting. After integrating it in v3 I realized that it would be more helpful if this function also returns some metadata/info about the round.