### PR TITLE
Simplify e2e network sync

### DIFF
--- a/e2e/e2e_partition_test.go
+++ b/e2e/e2e_partition_test.go
@@ -61,7 +61,7 @@ func TestE2E_Partition_MajorityCanValidate(t *testing.T) {
 	// restart minority and wait to sync
 	for _, node := range c.Nodes() {
 		if node.name >= "prt_"+strconv.Itoa(limit) {
-			node.Restart()
+			node.setFaultyNode(false)
 		}
 	}
 	err = c.WaitForHeight(4, 1*time.Minute)

--- a/e2e/e2e_partition_test.go
+++ b/e2e/e2e_partition_test.go
@@ -61,7 +61,7 @@ func TestE2E_Partition_MajorityCanValidate(t *testing.T) {
 	// restart minority and wait to sync
 	for _, node := range c.Nodes() {
 		if node.name >= "prt_"+strconv.Itoa(limit) {
-			node.setFaultyNode(false)
+			node.Restart()
 		}
 	}
 	err = c.WaitForHeight(4, 1*time.Minute)


### PR DESCRIPTION
Implementation of simplified node sync. Node is persisting only index up to which is in sync with the network. All finalized blocks and last proposer are persisted in the cluster (`sealedProposals`, `proposer`). Synchronization is done by checking current height of the network and setting node `syncIndex`.  