### PR TITLE
Wait for node to stop.

### DIFF
--- a/e2e/framework.go
+++ b/e2e/framework.go
@@ -221,11 +221,6 @@ func (c *cluster) StopNode(name string) {
 func (c *cluster) Stop() {
 	for _, n := range c.nodes {
 		n.Stop()
-		for {
-			if !n.IsRunning() {
-				break
-			}
-		}
 	}
 	if err := c.tracer.Shutdown(context.Background()); err != nil {
 		panic("failed to shutdown TracerProvider")

--- a/e2e/framework.go
+++ b/e2e/framework.go
@@ -244,7 +244,7 @@ type node struct {
 	name     string
 	pbft     *pbft.Pbft
 	cancelFn context.CancelFunc
-	stopped  uint64
+	running  uint64
 
 	// validator nodes
 	nodes []string
@@ -276,7 +276,7 @@ func newPBFTNode(name string, nodes []string, trace trace.Tracer, tt *transport)
 		proposals: []*pbft.SealedProposal{},
 		name:      name,
 		pbft:      con,
-		stopped:   0,
+		running:   0,
 	}
 	return n, nil
 }
@@ -344,10 +344,10 @@ func (n *node) Start() {
 	// create the ctx and the cancelFn
 	ctx, cancelFn := context.WithCancel(context.Background())
 	n.cancelFn = cancelFn
-	atomic.StoreUint64(&n.stopped, 1)
+	atomic.StoreUint64(&n.running, 1)
 	go func() {
 		defer func() {
-			atomic.StoreUint64(&n.stopped, 0)
+			atomic.StoreUint64(&n.running, 0)
 		}()
 	SYNC:
 		// 'sync up' with the network
@@ -396,7 +396,7 @@ func (n *node) Stop() {
 }
 
 func (n *node) IsRunning() bool {
-	return atomic.LoadUint64(&n.stopped) != 0
+	return atomic.LoadUint64(&n.running) != 0
 }
 
 func (n *node) Restart() {


### PR DESCRIPTION
Wait for node to stop since `CancelFunc` does not wait for the work to stop. Multiple start/stop for a node (e.g in fuzz framework) will be sequential and there will be no concurrent access inside node and hanging routines. 