### PR TITLE
Fixed partitions reset issue when node gets isolated

### DIFF
--- a/e2e/transport.go
+++ b/e2e/transport.go
@@ -88,6 +88,10 @@ func newPartitionTransport(jitterMax time.Duration) *partitionTransport {
 }
 
 func (p *partitionTransport) isConnected(from, to pbft.NodeID) bool {
+	if p.subsets == nil {
+		return true
+	}
+
 	subset, ok := p.subsets[string(from)]
 	if !ok {
 		// if not set, they are connected
@@ -115,7 +119,7 @@ func (p *partitionTransport) Reset() {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
-	p.subsets = map[string][]string{}
+	p.subsets = nil
 }
 
 func (p *partitionTransport) GetPartitions() map[string][]string {


### PR DESCRIPTION
Fixed the issue on partitions reset when reverting `PartitionAction`, where a node gets isolated from the rest of the network and stops communicating with other nodes.

When calling Reset on a partition, `PartitionTransport` subsets were set to an empty map, which can lead to isolation of a given node, since `Gossip` will check if a node is connected to another node, and since its subset is empty it will return false and node will get stuck.

This is solved by setting subsets map on `PartitionTransport` to `nil` on `Reset`, and `nil` is handled in `isConnected` method as a valid case which means that given node is connected to the entire network.
When another `PartitionAction` is created it will set it its map to another partition and action can proceed to execute.

**NOTE** For flow map, given behavior will be implemented and pushed when it gets merged with this branch.