### PR TITLE
Create quorum size partitions which is enough to create consensus.

### DIFF
--- a/consensus.go
+++ b/consensus.go
@@ -450,7 +450,7 @@ func (p *Pbft) runValidateState(ctx context.Context) { // start new round
 		}
 
 		if p.state.numPrepared() > p.state.NumValid() {
-			// we have received enough pre-prepare messages
+			// we have received enough prepare messages
 			sendCommit(span)
 		}
 

--- a/e2e/actions.go
+++ b/e2e/actions.go
@@ -37,6 +37,7 @@ func (dn *DropNodeAction) Apply(c *Cluster) RevertFunc {
 	c.StopNode(nodeToStop.name)
 
 	return func() {
+		log.Printf("Reverting stopped node %v\n", nodeToStop.name)
 		nodeToStop.Start()
 	}
 }
@@ -49,14 +50,16 @@ func (action *PartitionAction) CanApply(c *Cluster) bool {
 }
 
 func (action *PartitionAction) Apply(c *Cluster) RevertFunc {
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	hook := newPartitionTransport(500 * time.Millisecond)
 	// create 2 partition with random number of nodes
-	// minority with no more than max faulty nodes and majority with the rest of the nodes
-	maxFaultyNodes := pbft.MaxFaultyNodes(len(c.nodes))
+	// minority with less than quorum size nodes and majority with the rest of the nodes
+	quorumSize := pbft.QuorumSize(len(c.nodes))
 
 	var minorityPartition []string
 	var majorityPartition []string
-	minorityPartitionSize := rand.Intn(maxFaultyNodes + 1)
+	minorityPartitionSize := rand.Intn(quorumSize + 1)
 	i := 0
 	for n := range c.nodes {
 		if i < minorityPartitionSize {
@@ -72,6 +75,8 @@ func (action *PartitionAction) Apply(c *Cluster) RevertFunc {
 	c.hook = hook
 
 	return func() {
+		c.lock.Lock()
+		defer c.lock.Unlock()
 		log.Println("Reverting partitions.")
 		c.hook.Reset()
 	}

--- a/e2e/fuzz/runner.go
+++ b/e2e/fuzz/runner.go
@@ -147,8 +147,7 @@ func validateCluster(c *e2e.Cluster) ([]string, bool) {
 			runningNodes = append(runningNodes, n.GetName())
 		}
 	}
-	stoppedNodesCount := totalNodesCount - len(runningNodes)
-	return runningNodes, stoppedNodesCount <= pbft.MaxFaultyNodes(totalNodesCount)
+	return runningNodes, len(runningNodes) >= pbft.QuorumSize(totalNodesCount)
 }
 
 func getAvailableActions() []e2e.FunctionalAction {


### PR DESCRIPTION
Use quorum size instead of max faulty nodes when creating minority and majority partitions.
Also apply cluster lock when applying/revert partition action. 
Improve logging.