### PR TITLE
Node sends message to itself twice

### DIFF
--- a/e2e/transport.go
+++ b/e2e/transport.go
@@ -28,6 +28,9 @@ func (t *transport) Register(name pbft.NodeID, handler transportHandler) {
 
 func (t *transport) Gossip(msg *pbft.MessageReq) error {
 	for to, handler := range t.nodes {
+		if msg.From == to {
+			continue
+		}
 		go func(to pbft.NodeID, handler transportHandler) {
 			send := true
 			if t.hook != nil {


### PR DESCRIPTION
During troubleshooting of messages replay feature and dumping message queues content, it was noticed that there are same messages repeated within the queue. Repeated messages are those which node "sends" to itself.
The reason is that implementation of `Gossip` function in `e2e/transport.go` does not take into account that `gossip` function in `consensus.go` pushes message into the queue of given state machine (code snippet below).

```Go
if msg.Type != MessageReq_Preprepare {
    // send a copy to ourselves so that we can process this message as well
    msg2 := msg.Copy()
    msg2.From = p.validator.NodeID()
    p.PushMessage(msg2)
}
```
Therefore once `Gossip` in `transport` implementation is invoked it pushes that very same message again, so there are two instances of those messages.

This issue is minor, due to the fact we are relying on the `map[sender node id]*MessageReq` (refer to the snippet below) when counting `PREPARE` and `COMMIT` messages in consensus.go (otherwise if there wasn't that, these repeated messages would cause a more severe troubles, since those messages would be counted twice, although it should be only once, since it is the same message basically).

```Go
// List of prepared messages
prepared map[NodeID]*MessageReq
// List of committed messages
committed map[NodeID]*MessageReq
```