### PR TITLE
Prevent insertion of duplicate sealed proposals on different indices

### DIFF
--- a/e2e/framework_test.go
+++ b/e2e/framework_test.go
@@ -1,0 +1,39 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ClusterInsertFinalProposal(t *testing.T) {
+	c := newPBFTCluster(t, "cluster", "N", 3)
+
+	// valid proposal => insert it
+	seq1Proposal := newSealedProposal([]byte{0x1}, "N0", 1)
+	err := c.insertFinalProposal(seq1Proposal)
+	assert.Nil(t, err)
+	assert.Len(t, c.sealedProposals, 1)
+
+	// invalid proposal (different proposal data on sequence previously inserted) => discard it and return an error
+	seq1DiffProposal := newSealedProposal([]byte{0x3}, "N0", 1)
+	err = c.insertFinalProposal(seq1DiffProposal)
+	assert.NotNil(t, err)
+	assert.Len(t, c.sealedProposals, 1)
+
+	// same proposal data on same sequence previously entered => discard it, but don't return an error
+	err = c.insertFinalProposal(seq1Proposal)
+	assert.Nil(t, err)
+	assert.Len(t, c.sealedProposals, 1)
+
+	// sequence-gapped proposal => discard it and return an error
+	seq5Proposal := newSealedProposal([]byte{0x5}, "N1", 5)
+	err = c.insertFinalProposal(seq5Proposal)
+	assert.NotNil(t, err)
+	assert.Len(t, c.sealedProposals, 1)
+
+	// valid proposal => insert it
+	seq2Proposal := newSealedProposal([]byte{0x2}, "N1", 2)
+	c.insertFinalProposal(seq2Proposal)
+	assert.Len(t, c.sealedProposals, 2)
+}


### PR DESCRIPTION
### Introduction and context
Different nodes (the ones which were found on some of the previous sequences) were inserting same sealed proposals on different indices within the sealed proposals slice. 
Major part of making replay messages work properly was down to this problem. It was the reason why proposer calculation was incorrect when performing replay messages (last proposer is calculated based on last inserted sealed proposal, which holds information about proposer as well whereas current proposer is `indexOf(lastProposer) + round + 1`).

### Explanation
Since all the nodes are sharing sealed proposals, which is cached on a single place, within the cluster (changes made through PR https://github.com/0xPolygon/pbft-consensus/pull/35) and due to the fact that different nodes can found themselves on different sequences, nodes were trying to insert repeated sealed proposals on different index within a `sealedProposals` slice, held by `e2e.Cluster`. This issue occurs when some of the nodes have enough messages to insert a sealed proposal for `sequence+1`, whereas others are finalizing a sealed proposal for `sequence`.

This was the case because of logical condition for checking whether same proposal already exists as shown in snippet below (`insertIndex == uint64(lastIndex)`), which was checking whether proposal already exists only if insertion index is the same as last index:

```Go
lastIndex := len(c.sealedProposals) - 1
insertIndex := p.Number - 1
if insertIndex == uint64(lastIndex) {
	// already exists
	if !c.sealedProposals[insertIndex].Proposal.Equal(p.Proposal) {
		panic("Proposals are not equal")
	}
	pbft.Log(fmt.Sprintf("Proposal repeated %+v. InsertIndex=%d, LastIndex=%d\n", p, insertIndex, lastIndex))
}
```

#### Example
We have a cluster of 3 nodes: {N0, N1, N2} and all the messages for sequences 1 and 2 are already present within the message queues for all the nodes (which is the case in [replay messages](https://github.com/0xPolygon/pbft-consensus/pull/38) feature). 

N0 is the proposer for the sequence 1 and it gossips PRE-PREPARE and PREPARE messages to N1 and N2. N1 and N2 respond to N0 and each other with PREPARE (and COMMIT) messages, so they are eligible to seal a proposal and insert it, which they do. Only one of them will do so, since the second one, a condition which is checking if proposal already exists (`insertIndex == uint64(lastIndex)`) is going to be triggered. At this moment sealed proposals looks like this (let's imagine for simplicity that proposal data will always contain sequence which corresponds to the one when the proposal is built):
Sealed Proposals=[Seq=1 Proposer=N0 Proposal=[1]].

N1 and N2 advances to sequence 2. N1 is proposer and it relay PRE-PREPARE and PREPARE messages with N2, so once they have relayed enough PREPARE (and COMMIT) messages, each of these two will try to insert sealed proposal for sequence 2, which they do, but again, only 1st one who attempts will be successful. Sealed proposals slice looks like this:
Sealed Proposals=[Seq=1 Proposer=N0 Proposal=[1], Seq=2 Proposer=N1, Proposal=[2]].
At this point N0 manages to insert sealed proposal for sequence 1 and it will eventually manage to append it to the end, since `lastIndex = 2 - 1 = 1` and `insertIndex = 1 - 1 = 0` and `insertIndex != lastIndex`, which means that else branch is getting executed. Sealed proposals at this point is like this (bold one sealed proposal is repeated):
Sealed Proposals=[Seq=1 Proposer=N0 Proposal=[1], Seq=2 Proposer=N1 Proposal=[2], **Seq=1 Proposer=N0 Proposal=[1]**]. This means that last proposer will be wrong for some of next sequence (either 3 or 4, although most often 4, because at this point N1 and N2 are already processing sequence 3). 

### Resolution proposal
Since nodes are running independently, we cannot rely that if insertion index is different than last inserted index, proposals aren't repeated. Therefore we should check if proposals are the same even if insertion index is less than or equal to last inserted index. Also, whenever a sealed proposal is being inserted, we should iterate through whole sealed proposals slice and detect whether there is the one which holds same data and is already inserted.