### PR TITLE
Fix applying partition action 

### DIFF
--- a/consensus.go
+++ b/consensus.go
@@ -746,6 +746,16 @@ func (p *Pbft) setState(s PbftState) {
 	p.state.setState(s)
 }
 
+// IsLocked returns if the current proposal is locked
+func (p *Pbft) IsLocked() bool {
+	return p.state.locked
+}
+
+// GetProposal returns current proposal in the pbft
+func (p *Pbft) GetProposal() *Proposal {
+	return p.state.proposal
+}
+
 // getNextMessage reads a new message from the message queue
 func (p *Pbft) getNextMessage(span trace.Span, timeout time.Duration) (*MessageReq, bool) {
 	timeoutCh := time.After(timeout)

--- a/e2e/actions.go
+++ b/e2e/actions.go
@@ -45,7 +45,7 @@ func (dn *DropNodeAction) Apply(c *Cluster) RevertFunc {
 type PartitionAction struct {
 }
 
-func (action *PartitionAction) CanApply(c *Cluster) bool {
+func (action *PartitionAction) CanApply(_ *Cluster) bool {
 	return true
 }
 
@@ -72,12 +72,14 @@ func (action *PartitionAction) Apply(c *Cluster) RevertFunc {
 	log.Printf("Partitions ratio %d/%d, [%v], [%v]\n", len(majorityPartition), len(minorityPartition), majorityPartition, minorityPartition)
 	hook.Partition(minorityPartition, majorityPartition)
 
-	c.hook = hook
+	c.SetHook(hook)
 
 	return func() {
 		c.lock.Lock()
 		defer c.lock.Unlock()
 		log.Println("Reverting partitions.")
-		c.hook.Reset()
+		if tHook := c.transport.getHook(); tHook != nil {
+			tHook.Reset()
+		}
 	}
 }

--- a/e2e/fuzz/runner.go
+++ b/e2e/fuzz/runner.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	revertProbabilityThreshold = 20
-	waitForHeightTimeInterval  = 3 * time.Minute
+	waitForHeightTimeInterval  = 10 * time.Minute
 )
 
 type Runner struct {
@@ -106,7 +106,7 @@ func validateNodes(c *e2e.Cluster) {
 				log.Printf("Cluster partitions: %v\n", transportHook.GetPartitions())
 			}
 			for _, n := range c.Nodes() {
-				log.Printf("Node: %v, running: %v\n", n.GetName(), n.IsRunning())
+				log.Printf("Node: %v, running: %v, locked: %v, height: %v, proposal: %v\n", n.GetName(), n.IsRunning(), n.IsLocked(), n.GetNodeHeight(), n.GetProposal())
 			}
 			panic("Desired height not reached.")
 		}


### PR DESCRIPTION
This PR fixes applying partition action in FUZZ runner where subset of connected nodes is applied to the transport itself and not to the `transportHook` within the `cluster` which is not taken into consideration in `Gossip` method. 
Also added info about the node internal state (if node is locked, current height and proposal) if the desired height is not reached within the defined amount of time. 