### PR TITLE
Improve stopping of nodes after finishing all messages

### DIFF
--- a/e2e/fuzz/replay/replay_message_command.go
+++ b/e2e/fuzz/replay/replay_message_command.go
@@ -92,6 +92,7 @@ func (rmc *ReplayMessageCommand) Run(args []string) int {
 			select {
 			case nodeDone := <-messageReader.msgProcessingDone:
 				nodesDone[nodeDone] = true
+				cluster.StopNode(nodeDone)
 				if len(nodesDone) == nodesCount {
 					wg.Done()
 					return

--- a/e2e/fuzz/replay/replay_message_reader.go
+++ b/e2e/fuzz/replay/replay_message_reader.go
@@ -2,6 +2,7 @@ package replay
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -14,19 +15,23 @@ import (
 )
 
 const (
-	maxCharactersPerLine   = 2048 * 1024 // Increase Scanner buffer size to 2MB per line
-	roundMessagesWaitLimit = 50
-	messageChunkSize       = 200
+	maxCharactersPerLine = 2048 * 1024 // Increase Scanner buffer size to 2MB per line
+	messageChunkSize     = 200
 )
+
+type sequenceMessages struct {
+	sequence uint64
+	messages []*pbft.MessageReq
+}
 
 // replayMessageReader encapsulates logic for reading messages from flow file
 type replayMessageReader struct {
 	lock                   sync.Mutex
 	file                   *os.File
 	scanner                *bufio.Scanner
-	lastSequence           uint64
 	msgProcessingDone      chan string
 	nodesDoneWithExecution map[pbft.NodeID]bool
+	lastSequenceMessages   map[pbft.NodeID]*sequenceMessages
 }
 
 // openFile opens the file on provided location
@@ -74,12 +79,19 @@ func (r *replayMessageReader) readNodeMetaData() ([]string, error) {
 // readMessages reads messages from open .flow file and pushes them to appropriate nodes
 func (r *replayMessageReader) readMessages(cluster *e2e.Cluster) {
 	nodes := cluster.GetNodesMap()
-	r.nodesDoneWithExecution = make(map[pbft.NodeID]bool, len(nodes))
+
+	nodesCount := len(nodes)
+	r.nodesDoneWithExecution = make(map[pbft.NodeID]bool, nodesCount)
+	r.lastSequenceMessages = make(map[pbft.NodeID]*sequenceMessages, nodesCount)
 
 	messagesChannel := make(chan []*ReplayMessage)
 	doneChannel := make(chan struct{})
 
 	r.startChunkReading(messagesChannel, doneChannel)
+	nodeMessages := make(map[pbft.NodeID]map[uint64][]*pbft.MessageReq, nodesCount)
+	for _, n := range nodes {
+		nodeMessages[pbft.NodeID(n.GetName())] = make(map[uint64][]*pbft.MessageReq)
+	}
 
 	isDone := false
 LOOP:
@@ -92,12 +104,25 @@ LOOP:
 					log.Println(fmt.Sprintf("[WARNING] Could not find node: %v to push message from .flow file", message.To))
 				} else {
 					node.PushMessageInternal(message.Message)
-					if r.lastSequence < message.Message.View.Sequence {
-						r.lastSequence = message.Message.View.Sequence
-					}
+					nodeMessages[message.To][message.Message.View.Sequence] = append(nodeMessages[message.To][message.Message.View.Sequence], message.Message)
 				}
 			}
 		case <-doneChannel:
+			for name, n := range nodeMessages {
+				var nodeLastSequence uint64
+				nodeLastSequence = 0
+				for sequence := range n {
+					if nodeLastSequence < sequence {
+						nodeLastSequence = sequence
+					}
+				}
+
+				r.lastSequenceMessages[name] = &sequenceMessages{
+					sequence: nodeLastSequence,
+					messages: nodeMessages[name][nodeLastSequence],
+				}
+			}
+
 			isDone = true
 			break LOOP
 		}
@@ -135,28 +160,59 @@ func (r *replayMessageReader) startChunkReading(messagesChannel chan []*ReplayMe
 	}()
 }
 
-// checks if given node is done with execution of messages
-func (r *replayMessageReader) checkIfDoneWithExecution(validatorId pbft.NodeID, msg *pbft.MessageReq) {
-	//when nodes reach sequence that is higher than the sequence in file,
-	//or if it is in constant round change we know we either reached the end of execution or nodes are stuck and there is a problem
-	if msg.View.Sequence > r.lastSequence ||
-		isSequenceInContinuousRoundChange(msg, validatorId) {
+// processMessage checks if message is a timeout, or if all messages have been read from the queue
+func (r *replayMessageReader) processMessage(validatorId pbft.NodeID, msg *pbft.MessageReq) bool {
+	if isTimeoutMessage(msg) {
+		return true
+	}
+
+	if msg.View.Sequence > r.lastSequenceMessages[validatorId].sequence ||
+		(msg.View.Sequence == r.lastSequenceMessages[validatorId].sequence && r.areMessagesFromLastSequenceProcessed(msg, validatorId)) {
 		r.lock.Lock()
-		if _, isDone := r.nodesDoneWithExecution[validatorId]; !isDone {
+		_, isDone := r.nodesDoneWithExecution[validatorId]
+		if !isDone {
 			r.nodesDoneWithExecution[validatorId] = true
 			r.msgProcessingDone <- string(validatorId)
 		}
 		r.lock.Unlock()
 	}
+
+	return false
+}
+
+// areMessagesFromLastSequenceProcessed checks if all the messages from the last sequence of given node are processed so that the node can be stoped
+func (r *replayMessageReader) areMessagesFromLastSequenceProcessed(msg *pbft.MessageReq, validatorId pbft.NodeID) bool {
+	lastSequenceMessages := r.lastSequenceMessages[validatorId]
+
+	if len(lastSequenceMessages.messages) == 0 {
+		return true
+	} else {
+		messageIndexToRemove := -1
+		for i, message := range lastSequenceMessages.messages {
+			if areMessagesEqual(msg, message) {
+				messageIndexToRemove = i
+			}
+		}
+
+		if messageIndexToRemove != -1 {
+			lastSequenceMessages.messages = append(lastSequenceMessages.messages[:messageIndexToRemove], lastSequenceMessages.messages[messageIndexToRemove+1:]...)
+		}
+
+		return len(lastSequenceMessages.messages) == 0
+	}
+}
+
+// areMessagesEqual compares if two messages are equal
+func areMessagesEqual(msgOne, msgTwo *pbft.MessageReq) bool {
+	return msgOne.Type == msgTwo.Type && msgOne.From == msgTwo.From &&
+		bytes.Equal(msgOne.Proposal, msgTwo.Proposal) &&
+		bytes.Equal(msgOne.Hash, msgTwo.Hash) &&
+		bytes.Equal(msgOne.Seal, msgTwo.Seal) &&
+		msgOne.View.Round == msgTwo.View.Round &&
+		msgOne.View.Sequence == msgTwo.View.Sequence
 }
 
 // isTimeoutMessage checks if message in .flow file represents a timeout
 func isTimeoutMessage(message *pbft.MessageReq) bool {
 	return message.Hash == nil && message.Proposal == nil && message.Seal == nil && message.From == ""
-}
-
-// isSequenceInContinuousRoundChange checks if node is stuck in continuous round change
-// means either all messages are read and processed from file and nodes can not reach a consensus for next proposal, or there is some problem
-func isSequenceInContinuousRoundChange(msg *pbft.MessageReq, validatorId pbft.NodeID) bool {
-	return msg.Type == pbft.MessageReq_RoundChange && msg.View.Round >= roundMessagesWaitLimit
 }

--- a/e2e/fuzz/replay/replay_messages_notifier.go
+++ b/e2e/fuzz/replay/replay_messages_notifier.go
@@ -53,8 +53,12 @@ func (r *ReplayMessagesNotifier) HandleTimeout(to pbft.NodeID, msgType pbft.MsgT
 func (r *ReplayMessagesNotifier) ReadNextMessage(p *pbft.Pbft) (*pbft.MessageReq, []*pbft.MessageReq) {
 	msg, discards := p.ReadMessageWithDiscards()
 
-	if r.messageReader != nil && msg != nil && r.messageReader.processMessage(p.GetValidatorId(), msg) {
-		return nil, nil
+	if r.messageReader != nil && msg != nil {
+		if isTimeoutMessage(msg) {
+			return nil, nil
+		} else {
+			r.messageReader.checkIfDoneWithExecution(p.GetValidatorId(), msg)
+		}
 	}
 
 	return msg, discards

--- a/e2e/fuzz/replay/replay_messages_notifier.go
+++ b/e2e/fuzz/replay/replay_messages_notifier.go
@@ -53,12 +53,8 @@ func (r *ReplayMessagesNotifier) HandleTimeout(to pbft.NodeID, msgType pbft.MsgT
 func (r *ReplayMessagesNotifier) ReadNextMessage(p *pbft.Pbft) (*pbft.MessageReq, []*pbft.MessageReq) {
 	msg, discards := p.ReadMessageWithDiscards()
 
-	if r.messageReader != nil && msg != nil {
-		if isTimeoutMessage(msg) {
-			return nil, nil
-		} else {
-			r.messageReader.checkIfDoneWithExecution(p.GetValidatorId(), msg)
-		}
+	if r.messageReader != nil && msg != nil && r.messageReader.processMessage(p.GetValidatorId(), msg) {
+		return nil, nil
 	}
 
 	return msg, discards

--- a/state.go
+++ b/state.go
@@ -86,6 +86,16 @@ func (m *MessageReq) Copy() *MessageReq {
 	return mm
 }
 
+// Equal compares if two messages are equal
+func (m *MessageReq) Equal(other *MessageReq) bool {
+	return m.Type == other.Type && m.From == other.From &&
+		bytes.Equal(m.Proposal, other.Proposal) &&
+		bytes.Equal(m.Hash, other.Hash) &&
+		bytes.Equal(m.Seal, other.Seal) &&
+		m.View.Round == other.View.Round &&
+		m.View.Sequence == other.View.Sequence
+}
+
 type View struct {
 	// round is the current round/height being finalized
 	Round uint64 `json:"round"`

--- a/state.go
+++ b/state.go
@@ -88,7 +88,8 @@ func (m *MessageReq) Copy() *MessageReq {
 
 // Equal compares if two messages are equal
 func (m *MessageReq) Equal(other *MessageReq) bool {
-	return m.Type == other.Type && m.From == other.From &&
+	return other != nil &&
+		m.Type == other.Type && m.From == other.From &&
 		bytes.Equal(m.Proposal, other.Proposal) &&
 		bytes.Equal(m.Hash, other.Hash) &&
 		bytes.Equal(m.Seal, other.Seal) &&


### PR DESCRIPTION
Improved stopping of nodes on replay after they reach their last sequence in file.

Now replay will wait for nodes to read and process all the messages that were in the .flow file for their last sequence, and then will stop nodes as they reach the end of their execution.

This way we do not need to wait for continuous `Round Change`, and we are certain that all messages from the last sequence were processed.