### PR TITLE
Shorten integration and fuzz tests execution

### DIFF
--- a/e2e/e2e_node_drop_test.go
+++ b/e2e/e2e_node_drop_test.go
@@ -8,25 +8,27 @@ import (
 )
 
 func TestE2E_NodeDrop(t *testing.T) {
+	t.Parallel()
 	config := &ClusterConfig{
-		Count:  5,
-		Name:   "node_drop",
-		Prefix: "ptr",
+		Count:        5,
+		Name:         "node_drop",
+		Prefix:       "ptr",
+		RoundTimeout: GetPredefinedTimeout(2 * time.Second),
 	}
 
 	c := NewPBFTCluster(t, config)
 	c.Start()
 	// wait for two heights and stop node 1
-	err := c.WaitForHeight(2, 1*time.Minute)
+	err := c.WaitForHeight(2, 3*time.Second)
 	assert.NoError(t, err)
 
 	c.StopNode("ptr_0")
-	err = c.WaitForHeight(15, 1*time.Minute, generateNodeNames(1, 4, "ptr_"))
+	err = c.WaitForHeight(10, 15*time.Second, generateNodeNames(1, 4, "ptr_"))
 	assert.NoError(t, err)
 
 	// sync dropped node by starting it again
 	c.StartNode("ptr_0")
-	err = c.WaitForHeight(15, 1*time.Minute)
+	err = c.WaitForHeight(10, 15*time.Second)
 	assert.NoError(t, err)
 
 	c.Stop()

--- a/e2e/e2e_noissue_test.go
+++ b/e2e/e2e_noissue_test.go
@@ -8,13 +8,15 @@ import (
 )
 
 func TestE2E_NoIssue(t *testing.T) {
+	t.Parallel()
 	config := &ClusterConfig{
-		Count:  5,
-		Name:   "noissue",
-		Prefix: "noissue",
+		Count:        5,
+		Name:         "noissue",
+		Prefix:       "noissue",
+		RoundTimeout: GetPredefinedTimeout(2 * time.Second),
 	}
 
-	c := NewPBFTCluster(t, config, newRandomTransport(300*time.Millisecond))
+	c := NewPBFTCluster(t, config, newRandomTransport(50*time.Millisecond))
 	c.Start()
 	defer c.Stop()
 

--- a/e2e/e2e_partition_test.go
+++ b/e2e/e2e_partition_test.go
@@ -10,13 +10,15 @@ import (
 )
 
 func TestE2E_Partition_OneMajority(t *testing.T) {
+	t.Parallel()
 	const nodesCnt = 5
-	hook := newPartitionTransport(300 * time.Millisecond)
+	hook := newPartitionTransport(50 * time.Millisecond)
 
 	config := &ClusterConfig{
-		Count:  nodesCnt,
-		Name:   "majority_partition",
-		Prefix: "prt",
+		Count:        nodesCnt,
+		Name:         "majority_partition",
+		Prefix:       "prt",
+		RoundTimeout: GetPredefinedTimeout(2 * time.Second),
 	}
 
 	c := NewPBFTCluster(t, config, hook)
@@ -51,13 +53,15 @@ func TestE2E_Partition_OneMajority(t *testing.T) {
 }
 
 func TestE2E_Partition_MajorityCanValidate(t *testing.T) {
-	const nodesCnt = 7 // N=3F + 1, F = 2
-	hook := newPartitionTransport(300 * time.Millisecond)
+	t.Parallel()
+	const nodesCnt = 7 // N = 3 * F + 1, F = 2
+	hook := newPartitionTransport(50 * time.Millisecond)
 
 	config := &ClusterConfig{
-		Count:  nodesCnt,
-		Name:   "majority_partition",
-		Prefix: "prt",
+		Count:        nodesCnt,
+		Name:         "majority_partition",
+		Prefix:       "prt",
+		RoundTimeout: GetPredefinedTimeout(2 * time.Second),
 	}
 
 	c := NewPBFTCluster(t, config, hook)
@@ -81,13 +85,15 @@ func TestE2E_Partition_MajorityCanValidate(t *testing.T) {
 }
 
 func TestE2E_Partition_MajorityCantValidate(t *testing.T) {
-	const nodesCnt = 7 // N=3F + 1, F = 2
-	hook := newPartitionTransport(300 * time.Millisecond)
+	t.Parallel()
+	const nodesCnt = 7 // N = 3 * F + 1, F = 2
+	hook := newPartitionTransport(50 * time.Millisecond)
 
 	config := &ClusterConfig{
-		Count:  nodesCnt,
-		Name:   "majority_partition",
-		Prefix: "prt",
+		Count:        nodesCnt,
+		Name:         "majority_partition",
+		Prefix:       "prt",
+		RoundTimeout: GetPredefinedTimeout(2 * time.Second),
 	}
 
 	c := NewPBFTCluster(t, config, hook)
@@ -103,13 +109,15 @@ func TestE2E_Partition_MajorityCantValidate(t *testing.T) {
 }
 
 func TestE2E_Partition_BigMajorityCantValidate(t *testing.T) {
+	t.Parallel()
 	const nodesCnt = 100
-	hook := newPartitionTransport(300 * time.Millisecond)
+	hook := newPartitionTransport(50 * time.Millisecond)
 
 	config := &ClusterConfig{
-		Count:  nodesCnt,
-		Name:   "majority_partition",
-		Prefix: "prt",
+		Count:        nodesCnt,
+		Name:         "majority_partition",
+		Prefix:       "prt",
+		RoundTimeout: GetPredefinedTimeout(2 * time.Second),
 	}
 
 	c := NewPBFTCluster(t, config, hook)

--- a/e2e/framework.go
+++ b/e2e/framework.go
@@ -254,9 +254,10 @@ func (c *Cluster) WaitForHeight(num uint64, timeout time.Duration, nodes ...[]st
 	}
 
 	timer := time.NewTimer(timeout)
+	defer timer.Stop()
 	for {
 		select {
-		case <-time.After(200 * time.Millisecond):
+		case <-time.After(300 * time.Millisecond):
 			if enough() {
 				return nil
 			}

--- a/e2e/fuzz/replay/replay_message_command.go
+++ b/e2e/fuzz/replay/replay_message_command.go
@@ -75,7 +75,7 @@ func (rmc *ReplayMessageCommand) Run(args []string) int {
 		Name:                  "fuzz_cluster",
 		Prefix:                prefix,
 		ReplayMessageNotifier: replayMessagesNotifier,
-		RoundTimeout:          roundTimeout,
+		RoundTimeout:          e2e.GetPredefinedTimeout(time.Millisecond),
 		TransportHandler:      func(to pbft.NodeID, msg *pbft.MessageReq) { replayMessagesNotifier.HandleMessage(to, msg) },
 		CreateBackend:         func() e2e.IntegrationBackend { return &ReplayBackend{messageReader: messageReader} },
 	}
@@ -124,11 +124,6 @@ func (rmc *ReplayMessageCommand) NewFlagSet() *flag.FlagSet {
 	flagSet.StringVar(&rmc.filePath, "file", "", "Full path to .flow file containing messages and timeouts to be replayed by the fuzz framework")
 
 	return flagSet
-}
-
-// roundTimeout is an implementation of roundTimeout in pbft
-func roundTimeout(round uint64) time.Duration {
-	return time.Millisecond
 }
 
 // validateInput parses arguments from CLI and validates their correctness

--- a/e2e/fuzz_network_churn_test.go
+++ b/e2e/fuzz_network_churn_test.go
@@ -12,14 +12,16 @@ import (
 func TestFuzz_NetworkChurn(t *testing.T) {
 	isFuzzEnabled(t)
 
+	t.Parallel()
 	rand.Seed(time.Now().Unix())
 	nodeCount := 20
 	maxFaulty := nodeCount/3 - 1
 	const prefix = "ptr_"
 	config := &ClusterConfig{
-		Count:  nodeCount,
-		Name:   "network_churn",
-		Prefix: "ptr",
+		Count:        nodeCount,
+		Name:         "network_churn",
+		Prefix:       "ptr",
+		RoundTimeout: GetPredefinedTimeout(2 * time.Second),
 	}
 
 	c := NewPBFTCluster(t, config)

--- a/e2e/fuzz_unreliable_network_test.go
+++ b/e2e/fuzz_unreliable_network_test.go
@@ -12,18 +12,20 @@ import (
 func TestFuzz_Unreliable_Network(t *testing.T) {
 	isFuzzEnabled(t)
 
+	t.Parallel()
 	rand.Seed(time.Now().Unix())
 	nodesCount := 20 + rand.Intn(11) // vary nodes [20,30]
 	maxFaulty := nodesCount/3 - 1
 	maxHeight := uint64(40)
 	currentHeight := uint64(0)
-	jitterMax := 500 * time.Millisecond
+	jitterMax := 300 * time.Millisecond
 	hook := newPartitionTransport(jitterMax)
 
 	config := &ClusterConfig{
-		Count:  nodesCount,
-		Name:   "network_unreliable",
-		Prefix: "prt",
+		Count:        nodesCount,
+		Name:         "network_unreliable",
+		Prefix:       "prt",
+		RoundTimeout: GetPredefinedTimeout(2 * time.Second),
 	}
 
 	c := NewPBFTCluster(t, config, hook)

--- a/e2e/helper.go
+++ b/e2e/helper.go
@@ -11,6 +11,8 @@ import (
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/0xPolygon/pbft-consensus"
 )
 
 func generateNodeNames(from int, count int, prefix string) []string {
@@ -106,4 +108,11 @@ func GetLoggerOutput(name string, logsDir string) io.Writer {
 		loggerOutput = os.Stdout
 	}
 	return loggerOutput
+}
+
+// GetPredefinedTimeout is a closure to the function which is returning given predefined timeout.
+func GetPredefinedTimeout(timeout time.Duration) pbft.RoundTimeout {
+	return func(u uint64) time.Duration {
+		return timeout
+	}
 }


### PR DESCRIPTION
This PR addresses duration of integration and fuzz tests.

Solution consists of:

1. Running tests in parallel. 
2. Each test now relies on predefined timeout for each round (which is set to 2 seconds).
3. `WaitForHeight` function, which checks whether all the nodes have reached desired height, queries nodes every 300 ms, instead of 200 ms. This change is made, because in a cluster with 5 nodes on a single machine with no latencies, blocks produce rate is 1 block/sec, therefore it seems it is enough to check whether nodes have made to reach given height ~3 times per second.
4. Latencies within partition transport and random transport hooks are reduced to some extent.

Execution of e2e tests is reduced from original ~4 minutes to ~1 minute.