### PR TITLE
Drop node simulation in replay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-SavedState/
+SavedState*/
 **/launch.json
 **/*.flow
 **/*.log

--- a/consensus.go
+++ b/consensus.go
@@ -756,7 +756,7 @@ func (p *Pbft) GetProposal() *Proposal {
 	return p.state.proposal
 }
 
-// GetCurrentView returnes current view
+// GetCurrentView returns current view
 func (p *Pbft) GetCurrentView() *View {
 	return p.state.view.Copy()
 }

--- a/e2e/actions.go
+++ b/e2e/actions.go
@@ -1,7 +1,6 @@
 package e2e
 
 import (
-	"encoding/json"
 	"log"
 	"math/rand"
 	"time"
@@ -14,37 +13,6 @@ const (
 	RevertDropNode string = "RevertDropNode"
 	LastSequence   string = "LastSequence"
 )
-
-// MetaData is a struct that holds data about fuzz actions that happened and need to be saved in .flow file
-type MetaData struct {
-	DataType string `json:"actionType"`
-	Data     string `json:"data"`
-	Sequence uint64 `json:"sequence"`
-	Round    uint64 `json:"round"`
-}
-
-// NewMetaData creates a new MetaData object
-func NewMetaData(dataType, data string, sequence, round uint64) *MetaData {
-	return &MetaData{
-		DataType: dataType,
-		Data:     data,
-		Sequence: sequence,
-		Round:    round,
-	}
-}
-
-// ConvertActionsToByteArrays converts ActionSerializable slice to JSON representation and returns it back as slice of byte arrays
-func ConvertActionsToByteArrays(actions []*MetaData) ([][]byte, error) {
-	var allRawACtions [][]byte
-	for _, message := range actions {
-		currentRawAction, err := json.Marshal(message)
-		if err != nil {
-			return allRawACtions, err
-		}
-		allRawACtions = append(allRawACtions, currentRawAction)
-	}
-	return allRawACtions, nil
-}
 
 type RevertFunc func()
 
@@ -74,12 +42,12 @@ func (dn *DropNodeAction) Apply(c *Cluster) RevertFunc {
 
 	c.StopNode(nodeToStop.name)
 	view := nodeToStop.GetCurrentView()
-	c.replayMessageNotifier.HandleAction(NewMetaData(DropNode, nodeToStop.name, view.Sequence, view.Round))
+	c.replayMessageNotifier.HandleAction(DropNode, nodeToStop.name, view.Sequence, view.Round)
 
 	return func() {
 		log.Printf("Reverting stopped node %v\n", nodeToStop.name)
 		nodeToStop.Start()
-		c.replayMessageNotifier.HandleAction(NewMetaData(RevertDropNode, nodeToStop.name, c.GetMaxHeight()+1, 0))
+		c.replayMessageNotifier.HandleAction(RevertDropNode, nodeToStop.name, c.GetMaxHeight()+1, 0)
 	}
 }
 

--- a/e2e/actions.go
+++ b/e2e/actions.go
@@ -12,7 +12,6 @@ import (
 const (
 	DropNode       string = "DropNode"
 	RevertDropNode string = "RevertDropNode"
-	Partition      string = "Partition"
 	LastSequence   string = "LastSequence"
 )
 

--- a/e2e/fuzz/README.md
+++ b/e2e/fuzz/README.md
@@ -35,9 +35,9 @@ Replay takes the provided `messages.flow` and `metaData.flow` files, creates a c
 
 To run replay messages, run the following command:
 
-`go run ./e2e/fuzz/cmd/main.go replay-messages -messagesFile={fullPathToMessagesFile} -metaDataFile={fullPathToMetaDataFile}`
+`go run ./e2e/fuzz/cmd/main.go replay-messages -filesDirectory={directoryWhereFlowFilesAreStored}`
 
-e.g., `go run ./e2e/fuzz/cmd/main.go replay-messages -messagesFile=../SavedData/messages.flow -metaDataFile=../SavedData/metaData.flow`
+e.g., `go run ./e2e/fuzz/cmd/main.go replay-messages -filesDirectory=../SavedData`
 
 **NOTE**: Replay does not save .flow files on its execution.
 

--- a/e2e/fuzz/README.md
+++ b/e2e/fuzz/README.md
@@ -1,0 +1,45 @@
+- [FUZZ FRAMEWORK](#fuzz-framework)
+  - [Daemon](#daemon)
+  - [Replay Messages](#replay-messages)
+  - [Known issues](#known-issues)
+
+# FUZZ FRAMEWORK
+
+Fuzz framework is an automated software testing framework that involves providing invalid, unexpected, or random data as inputs to a computer program. The program is then monitored for exceptions such as crashes, failing built-in code assertions, or potential memory leaks.
+
+Fuzz framework enables building randomized test sets upon PBFT consensus algorithm. The end goal of the fuzz framework is to ensure that even under stress conditions, we achieve linearity on the PBFT consensus protocol, this is, under some time bounds and conditions (i.e. we cannot produce a block, if there are zero nodes active), a new block is being produced.
+
+## Daemon
+Fuzz daemon represents a test runner for fuzz/randomized tests. It is a separate go module/process, which runs alongside the cluster of Pbft nodes.
+It runs a Go routine and a single cluster with predefined number of nodes and randomly picks some subset of predefined actions and applies those to the cluster.
+
+Supported actions that can be simulated in fuzz daemon are:
+1. Drop Node - simulates dropping of a node in cluster where a single node goes offline, and is not communicating with the rest of the network.
+2. Partitions - simulates grouping of nodes in seperate partitions, where each partition only communicates with its member nodes.
+3. Flow Map - simulates a message routing mechanism where some of the nodes within the cluster are fully connected, whereas some of them are partially connected (namely only to the subset of peer nodes).
+
+To run fuzz daemon (runner) run the following command:
+
+`go run ./e2e/fuzz/cmd/main.go fuzz-run -nodes={numberOfNodes} -duration={duration}`
+
+e.g., `go run ./e2e/fuzz/cmd/main.go fuzz-run -nodes=5 -duration=1h`
+
+To log node execution to separate log files for easier problem analysis, set environment variable `E2E_LOG_TO_FILES` to `true` before running the `fuzz-run` command. Logs are stored in the parent folder from which `fuzz-run` command was called, inside the `logs-{timestamp}` subfolder. Each node will have its own .log file where name of the file will be the name of the corresponding node.
+
+By default when running `fuzz-run` command, two `.flow` files will be saved containing all the messages that were gossiped during the fuzz daemon execution, alongside some meta data about actions that were simulated during fuzz running. Files are saved inside the parent folder from which `fuzz-run` command was called, inside the `SavedState` subfolder. File containing gossiped messages is named `messages-{timestamp}.flow`, and file containing node and actions meta data is called `metaData-{timestamp}.flow`. These files are needed to replay the fuzz exectuion using the **Replay Messages** feature.
+
+## Replay Messages
+Fuzz framework relies on a randomized set of predefined actions, which are applied and reverted on **PolyBFT** nodes cluster. Since its execution is non-deterministic and algorithm failure can be discovered at any time, it is of utmost importance to have trace of triggers which led to the failure state and possibility to replay those triggers on-demand arbitrary number of times. This feature enables in-depth analysis of failure.
+
+Replay takes the provided `messages.flow` and `metaData.flow` files, creates a cluster with appropriate amount of nodes with same name as in fuzz run, pushes all the messages in appropriate node queues and starts the cluster. This enables quick replay of previously run execution and a way to analyze the problem that occurred on demand.
+
+To run replay messages, run the following command:
+
+`go run ./e2e/fuzz/cmd/main.go replay-messages -messagesFile={fullPathToMessagesFile} -metaDataFile={fullPathToMetaDataFile}`
+
+e.g., `go run ./e2e/fuzz/cmd/main.go replay-messages -messagesFile=../SavedData/messages.flow -metaDataFile=../SavedData/metaData.flow`
+
+**NOTE**: Replay does not save .flow files on its execution.
+
+## Known issues
+When saving messages that are gossiped during the execution of fuzz daemon, messages will be sorted by sequence but they will not be in the order that they were gossiped, since `Gossip` method sends messages to each node asynchronously in separate go routins for each receiver. This means that a `PrePrepare` message may not be first in the `.flow` file since all the other messages are also sent in seperate routines. This does not have an effect or causes an issue on replay, since messages are seperated in different queues in **PolyBFT** state machine depending on its message type (`PrePrepare`, `Prepare`, `Commit`, `RoundChange`).

--- a/e2e/fuzz/README.md
+++ b/e2e/fuzz/README.md
@@ -16,7 +16,6 @@ It runs a Go routine and a single cluster with predefined number of nodes and ra
 Supported actions that can be simulated in fuzz daemon are:
 1. Drop Node - simulates dropping of a node in cluster where a single node goes offline, and is not communicating with the rest of the network.
 2. Partitions - simulates grouping of nodes in seperate partitions, where each partition only communicates with its member nodes.
-3. Flow Map - simulates a message routing mechanism where some of the nodes within the cluster are fully connected, whereas some of them are partially connected (namely only to the subset of peer nodes).
 
 To run fuzz daemon (runner) run the following command:
 
@@ -29,7 +28,7 @@ To log node execution to separate log files for easier problem analysis, set env
 By default when running `fuzz-run` command, two `.flow` files will be saved containing all the messages that were gossiped during the fuzz daemon execution, alongside some meta data about actions that were simulated during fuzz running. Files are saved inside the parent folder from which `fuzz-run` command was called, inside the `SavedState` subfolder. File containing gossiped messages is named `messages-{timestamp}.flow`, and file containing node and actions meta data is called `metaData-{timestamp}.flow`. These files are needed to replay the fuzz exectuion using the **Replay Messages** feature.
 
 ## Replay Messages
-Fuzz framework relies on a randomized set of predefined actions, which are applied and reverted on **PolyBFT** nodes cluster. Since its execution is non-deterministic and algorithm failure can be discovered at any time, it is of utmost importance to have trace of triggers which led to the failure state and possibility to replay those triggers on-demand arbitrary number of times. This feature enables in-depth analysis of failure.
+Fuzz framework relies on a randomized set of predefined actions, which are applied and reverted on **PBFT** nodes cluster. Since its execution is non-deterministic and algorithm failure can be discovered at any time, it is of utmost importance to have trace of triggers which led to the failure state and possibility to replay those triggers on-demand arbitrary number of times. This feature enables in-depth analysis of failure.
 
 Replay takes the provided `messages.flow` and `metaData.flow` files, creates a cluster with appropriate amount of nodes with same name as in fuzz run, pushes all the messages in appropriate node queues and starts the cluster. This enables quick replay of previously run execution and a way to analyze the problem that occurred on demand.
 
@@ -42,4 +41,4 @@ e.g., `go run ./e2e/fuzz/cmd/main.go replay-messages -filesDirectory=../SavedDat
 **NOTE**: Replay does not save .flow files on its execution.
 
 ## Known issues
-When saving messages that are gossiped during the execution of fuzz daemon, messages will be sorted by sequence but they will not be in the order that they were gossiped, since `Gossip` method sends messages to each node asynchronously in separate go routins for each receiver. This means that a `PrePrepare` message may not be first in the `.flow` file since all the other messages are also sent in seperate routines. This does not have an effect or causes an issue on replay, since messages are seperated in different queues in **PolyBFT** state machine depending on its message type (`PrePrepare`, `Prepare`, `Commit`, `RoundChange`).
+When saving messages that are gossiped during the execution of fuzz daemon, messages will be sorted by sequence but they will not be in the order that they were gossiped, since `Gossip` method sends messages to each node asynchronously in separate go routins for each receiver. This means that a `PrePrepare` message may not be first in the `.flow` file since all the other messages are also sent in seperate routines. This does not have an effect or causes an issue on replay, since messages are seperated in different queues in **PBFT** state machine depending on its message type (`PrePrepare`, `Prepare`, `Commit`, `RoundChange`).

--- a/e2e/fuzz/replay/replay_message.go
+++ b/e2e/fuzz/replay/replay_message.go
@@ -6,6 +6,24 @@ import (
 	"github.com/0xPolygon/pbft-consensus"
 )
 
+// MetaData is a struct that holds data about fuzz actions that happened and need to be saved in .flow file
+type MetaData struct {
+	DataType string `json:"actionType"`
+	Data     string `json:"data"`
+	Sequence uint64 `json:"sequence"`
+	Round    uint64 `json:"round"`
+}
+
+// NewMetaData creates a new MetaData object
+func NewMetaData(dataType, data string, sequence, round uint64) *MetaData {
+	return &MetaData{
+		DataType: dataType,
+		Data:     data,
+		Sequence: sequence,
+		Round:    round,
+	}
+}
+
 // ReplayMessage is a struct that represents a single json object in .flow file
 type ReplayMessage struct {
 	To      pbft.NodeID      `json:"to"`
@@ -31,10 +49,10 @@ func NewReplayTimeoutMessage(to pbft.NodeID, msgType pbft.MsgType, view *pbft.Vi
 	}
 }
 
-// ConvertMessagesToByteArrays converts ReplayMessage slice to JSON representation and return it back as slice of byte arrays
-func ConvertMessagesToByteArrays(messages []*ReplayMessage) ([][]byte, error) {
+// ConvertToByteArrays is a generic method that converts provided slice to JSON representation and returns it back as slice of byte arrays
+func ConvertToByteArrays(items []interface{}) ([][]byte, error) {
 	var allRawMessages [][]byte
-	for _, message := range messages {
+	for _, message := range items {
 		currentRawMessage, err := json.Marshal(message)
 		if err != nil {
 			return allRawMessages, err

--- a/e2e/fuzz/replay/replay_message.go
+++ b/e2e/fuzz/replay/replay_message.go
@@ -31,8 +31,8 @@ func NewReplayTimeoutMessage(to pbft.NodeID, msgType pbft.MsgType, view *pbft.Vi
 	}
 }
 
-// ConvertToByteArrays converts ReplayMessage slice to JSON representation and return it back as slice of byte arrays
-func ConvertToByteArrays(messages []*ReplayMessage) ([][]byte, error) {
+// ConvertMessagesToByteArrays converts ReplayMessage slice to JSON representation and return it back as slice of byte arrays
+func ConvertMessagesToByteArrays(messages []*ReplayMessage) ([][]byte, error) {
 	var allRawMessages [][]byte
 	for _, message := range messages {
 		currentRawMessage, err := json.Marshal(message)

--- a/e2e/fuzz/replay/replay_message_command.go
+++ b/e2e/fuzz/replay/replay_message_command.go
@@ -17,8 +17,7 @@ import (
 type ReplayMessageCommand struct {
 	UI cli.Ui
 
-	messagesFilePath string
-	metaDataFilePath string
+	filesDirectory string
 }
 
 // Help implements the cli.Command interface
@@ -29,8 +28,7 @@ func (rmc *ReplayMessageCommand) Help() string {
 	
 	Options:
 	
-	-messagesFile - Full path to .flow file containing messages and timeouts to be replayed by the fuzz framework
-	-metaDataFile - Full path to .flow file containing meta data for nodes and fuzz actions`
+	-filesDirectory - Directory containing .flow files for messages and actions meta data to be replayed by the fuzz framework`
 }
 
 // Synopsis implements the cli.Command interface
@@ -49,7 +47,7 @@ func (rmc *ReplayMessageCommand) Run(args []string) int {
 	messageReader := &replayMessageReader{}
 	nodeExecutionHandler := NewNodeExecutionHandler()
 
-	err = messageReader.openFiles(rmc.messagesFilePath, rmc.metaDataFilePath)
+	err = messageReader.openFiles(rmc.filesDirectory)
 	if err != nil {
 		rmc.UI.Error(err.Error())
 		return 1
@@ -101,8 +99,7 @@ func (rmc *ReplayMessageCommand) Run(args []string) int {
 // NewFlagSet implements the FuzzCLICommand interface and creates a new flag set for command arguments
 func (rmc *ReplayMessageCommand) NewFlagSet() *flag.FlagSet {
 	flagSet := flag.NewFlagSet("replay-messages", flag.ContinueOnError)
-	flagSet.StringVar(&rmc.messagesFilePath, "messagesFile", "", "Full path to .flow file containing messages and timeouts to be replayed by the fuzz framework")
-	flagSet.StringVar(&rmc.metaDataFilePath, "metaDataFile", "", "Full path to .flow file containing meta data for nodes and fuzz actions")
+	flagSet.StringVar(&rmc.filesDirectory, "filesDirectory", "", "Directory containing .flow files for messages and actions meta data to be replayed by the fuzz framework")
 
 	return flagSet
 }
@@ -115,13 +112,8 @@ func (rmc *ReplayMessageCommand) validateInput(args []string) error {
 		return err
 	}
 
-	if rmc.messagesFilePath == "" {
-		err = errors.New("provided messages file path is empty")
-		return err
-	}
-
-	if rmc.messagesFilePath == "" {
-		err = errors.New("provided meta data file path is empty")
+	if rmc.filesDirectory == "" {
+		err = errors.New("provided files directory is empty")
 		return err
 	}
 

--- a/e2e/fuzz/replay/replay_message_command.go
+++ b/e2e/fuzz/replay/replay_message_command.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/0xPolygon/pbft-consensus"
@@ -18,18 +17,20 @@ import (
 type ReplayMessageCommand struct {
 	UI cli.Ui
 
-	filePath string
+	messagesFilePath string
+	metaDataFilePath string
 }
 
 // Help implements the cli.Command interface
-func (fc *ReplayMessageCommand) Help() string {
+func (rmc *ReplayMessageCommand) Help() string {
 	return `Runs the message and timeouts replay for analysis and testing purposes based on provided .flow file.
 	
-	Usage: replay-messages -file={fullPathToFlowFile}
+	Usage: replay-messages -messagesFile={fullPathToFlowFile} -metaDataFile={fullPathToFlowFile}
 	
 	Options:
 	
-	-file - Full path to .flow file containing messages and timeouts to be replayed by the fuzz framework`
+	-messagesFile - Full path to .flow file containing messages and timeouts to be replayed by the fuzz framework
+	-metaDataFile - Full path to .flow file containing meta data for nodes and fuzz actions`
 }
 
 // Synopsis implements the cli.Command interface
@@ -45,17 +46,16 @@ func (rmc *ReplayMessageCommand) Run(args []string) int {
 		return 1
 	}
 
-	messageReader := &replayMessageReader{
-		msgProcessingDone: make(chan string),
-	}
+	messageReader := &replayMessageReader{}
+	nodeExecutionHandler := NewNodeExecutionHandler()
 
-	err = messageReader.openFile(rmc.filePath)
+	err = messageReader.openFiles(rmc.messagesFilePath, rmc.metaDataFilePath)
 	if err != nil {
 		rmc.UI.Error(err.Error())
 		return 1
 	}
 
-	nodeNames, err := messageReader.readNodeMetaData()
+	nodeNames, err := messageReader.readNodeMetaData(nodeExecutionHandler)
 	if err != nil {
 		rmc.UI.Error(err.Error())
 		return 1
@@ -67,47 +67,27 @@ func (rmc *ReplayMessageCommand) Run(args []string) int {
 		prefix = (nodeNames[0])[:i]
 	}
 
-	replayMessagesNotifier := NewReplayMessagesNotifierWithReader(messageReader)
+	replayMessagesNotifier := NewReplayMessagesNotifierForReplay(nodeExecutionHandler)
 
 	nodesCount := len(nodeNames)
+	var cluster *e2e.Cluster
 	config := &e2e.ClusterConfig{
 		Count:                 nodesCount,
 		Name:                  "fuzz_cluster",
 		Prefix:                prefix,
 		ReplayMessageNotifier: replayMessagesNotifier,
 		RoundTimeout:          e2e.GetPredefinedTimeout(time.Millisecond),
-		TransportHandler:      func(to pbft.NodeID, msg *pbft.MessageReq) { replayMessagesNotifier.HandleMessage(to, msg) },
+		TransportHandler:      func(to pbft.NodeID, msg *pbft.MessageReq) { /* we do not gossip messages in replay */ },
 		CreateBackend:         func() e2e.IntegrationBackend { return &ReplayBackend{messageReader: messageReader} },
 	}
 
-	cluster := e2e.NewPBFTCluster(nil, config)
+	cluster = e2e.NewPBFTCluster(nil, config)
 
-	messageReader.readMessages(cluster)
+	messageReader.readMessages(cluster, nodeExecutionHandler)
 	messageReader.closeFile()
 
-	var wg sync.WaitGroup
-	wg.Add(1)
-
-	nodesDone := make(map[string]bool, nodesCount)
-	go func() {
-		for {
-			select {
-			case nodeDone := <-messageReader.msgProcessingDone:
-				nodesDone[nodeDone] = true
-				cluster.StopNode(nodeDone)
-				if len(nodesDone) == nodesCount {
-					wg.Done()
-					return
-				}
-			default:
-				continue
-			}
-		}
-	}()
-
-	cluster.Start()
-	wg.Wait()
-	cluster.Stop()
+	nodeExecutionHandler.startActionSimulation(cluster)
+	nodeExecutionHandler.stopActionSimulation(cluster)
 
 	rmc.UI.Info("Done with execution")
 	if err = replayMessagesNotifier.CloseFile(); err != nil {
@@ -121,7 +101,8 @@ func (rmc *ReplayMessageCommand) Run(args []string) int {
 // NewFlagSet implements the FuzzCLICommand interface and creates a new flag set for command arguments
 func (rmc *ReplayMessageCommand) NewFlagSet() *flag.FlagSet {
 	flagSet := flag.NewFlagSet("replay-messages", flag.ContinueOnError)
-	flagSet.StringVar(&rmc.filePath, "file", "", "Full path to .flow file containing messages and timeouts to be replayed by the fuzz framework")
+	flagSet.StringVar(&rmc.messagesFilePath, "messagesFile", "", "Full path to .flow file containing messages and timeouts to be replayed by the fuzz framework")
+	flagSet.StringVar(&rmc.metaDataFilePath, "metaDataFile", "", "Full path to .flow file containing meta data for nodes and fuzz actions")
 
 	return flagSet
 }
@@ -134,10 +115,16 @@ func (rmc *ReplayMessageCommand) validateInput(args []string) error {
 		return err
 	}
 
-	if rmc.filePath == "" {
-		err = errors.New("provided file path is empty")
+	if rmc.messagesFilePath == "" {
+		err = errors.New("provided messages file path is empty")
 		return err
 	}
+
+	if rmc.messagesFilePath == "" {
+		err = errors.New("provided meta data file path is empty")
+		return err
+	}
+
 	return nil
 }
 

--- a/e2e/fuzz/replay/replay_message_persister.go
+++ b/e2e/fuzz/replay/replay_message_persister.go
@@ -4,31 +4,60 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
+
+	"github.com/0xPolygon/pbft-consensus/e2e"
 )
 
 const directoryPath = "../SavedState"
 
+// messagePersister is an interface for storing messages, node and action meta data to .flow files
+type messagePersister interface {
+	saveMetaData(nodeNames []string, lastSequences []*e2e.MetaData) error
+	saveCachedMessages() error
+	addAction(action *e2e.MetaData)
+	addMessage(message *ReplayMessage)
+	closeFile() error
+}
+
+// defaultMessagePersister is a default implementation of messagePersister interface
+type defaultMessagePersister struct{}
+
+func (d *defaultMessagePersister) saveMetaData(nodeNames []string, lastSequences []*e2e.MetaData) error {
+	return nil
+}
+func (d *defaultMessagePersister) saveCachedMessages() error         { return nil }
+func (d *defaultMessagePersister) addAction(action *e2e.MetaData)    {}
+func (d *defaultMessagePersister) addMessage(message *ReplayMessage) {}
+func (d *defaultMessagePersister) closeFile() error                  { return nil }
+
 // replayMessagePersister encapsulates logic for saving messages in .flow file
 type replayMessagePersister struct {
-	lock     sync.Mutex
-	messages []*ReplayMessage
-	file     *os.File
+	lock         sync.Mutex
+	timestamp    string
+	messages     []*ReplayMessage
+	messagesFile *os.File
+	metaDataFile *os.File
+	actions      []*e2e.MetaData
 }
 
 // saveMetaData saves node meta data to .flow file
-func (r *replayMessagePersister) saveMetaData(nodeNames *[]string) error {
+func (r *replayMessagePersister) saveMetaData(nodeNames []string, lastSequences []*e2e.MetaData) error {
 	var err error
-	if err = r.createFile(); err != nil {
-		return err
+	var file *os.File
+	if r.metaDataFile == nil {
+		if file, err = r.createFile(MetaDataFilePrefix); err != nil {
+			return err
+		}
+		r.metaDataFile = file
 	}
 
-	bufWriter := bufio.NewWriter(r.file)
-	defer bufWriter.Flush()
-
+	bufWriter := bufio.NewWriterSize(r.metaDataFile, maxCharactersPerLine)
 	currentRawMessage, err := json.Marshal(nodeNames)
 	if err != nil {
 		return err
@@ -39,7 +68,16 @@ func (r *replayMessagePersister) saveMetaData(nodeNames *[]string) error {
 		return err
 	}
 
-	_, err = bufWriter.Write([]byte("\n"))
+	bufWriter.Write([]byte("\n"))
+
+	raw, err := e2e.ConvertActionsToByteArrays(lastSequences)
+	if err != nil {
+		log.Printf("[ERROR] An error occurred while converting last sequences to byte arrays")
+	} else {
+		r.writeToFile(raw, bufWriter)
+	}
+
+	r.saveActions(bufWriter)
 
 	return err
 }
@@ -50,48 +88,27 @@ func (r *replayMessagePersister) saveCachedMessages() error {
 	defer r.lock.Unlock()
 
 	var err error
-	if err = r.createFile(); err != nil {
-		return err
+	var file *os.File
+	if r.messagesFile == nil {
+		if file, err = r.createFile(MessagesFilePrefix); err != nil {
+			return err
+		}
+		r.messagesFile = file
 	}
 
 	if r.messages != nil {
-		err = r.saveMessages(r.file)
+		err = r.saveMessages()
 	}
 
 	return err
 }
 
-// createFile creates a .flow file to save messages and timeouts on the predifined location
-func (r *replayMessagePersister) createFile() error {
-	if r.file == nil {
-		if _, err := os.Stat(directoryPath); os.IsNotExist(err) {
-			err := os.Mkdir(directoryPath, 0777)
-			if err != nil {
-				return err
-			}
-		}
+// addAction adds an action that happened in fuzz to cache that will be saved to .flow file on cluster Stop
+func (r *replayMessagePersister) addAction(action *e2e.MetaData) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
 
-		path, err := filepath.Abs(directoryPath)
-		if err != nil {
-			return err
-		}
-
-		file, err := os.OpenFile(filepath.Join(path, fmt.Sprintf("%v_%v.flow", FileName, time.Now().Format(time.RFC3339))), os.O_RDWR|os.O_APPEND|os.O_CREATE, 0660)
-		if err != nil {
-			return err
-		}
-		r.file = file
-	}
-
-	return nil
-}
-
-// closeFile closes file created by the ReplayMessagesHandler if it is open
-func (r *replayMessagePersister) closeFile() error {
-	if r.file != nil {
-		return r.file.Close()
-	}
-	return nil
+	r.actions = append(r.actions, action)
 }
 
 // addMessage adds a message from sequence to messages cache that will be written to .flow file
@@ -102,17 +119,39 @@ func (r *replayMessagePersister) addMessage(message *ReplayMessage) {
 }
 
 // saveMessages saves ReplayMessages to the JSON file within the pre-defined directory.
-func (r *replayMessagePersister) saveMessages(fileWriter *os.File) error {
-	rawMessages, err := ConvertToByteArrays(r.messages)
+func (r *replayMessagePersister) saveMessages() error {
+	rawMessages, err := ConvertMessagesToByteArrays(r.messages)
 	if err != nil {
 		return err
 	}
 
-	bufWriter := bufio.NewWriterSize(fileWriter, maxCharactersPerLine)
-	defer bufWriter.Flush()
+	bufWritter := bufio.NewWriterSize(r.messagesFile, maxCharactersPerLine)
+	r.writeToFile(rawMessages, bufWritter)
+	r.messages = nil
 
-	for _, rawMessage := range rawMessages {
-		_, err = bufWriter.Write(rawMessage)
+	return nil
+}
+
+// saveActions saves cached actions to .flow file
+func (r *replayMessagePersister) saveActions(bufWritter *bufio.Writer) {
+	rawActions, err := e2e.ConvertActionsToByteArrays(r.actions)
+	if err != nil {
+		log.Printf("[ERROR] An error occurred while converting actions to byte arrays")
+		return
+	}
+
+	if len(rawActions) == 0 { //no actions were done in fuzz
+		return
+	}
+
+	r.writeToFile(rawActions, bufWritter)
+}
+
+// writeToFile writes that to designated file using bufio writer
+func (r *replayMessagePersister) writeToFile(data [][]byte, bufWriter *bufio.Writer) error {
+
+	for _, rawMessage := range data {
+		_, err := bufWriter.Write(rawMessage)
 		if err != nil {
 			return err
 		}
@@ -123,6 +162,54 @@ func (r *replayMessagePersister) saveMessages(fileWriter *os.File) error {
 		}
 	}
 
-	r.messages = nil
+	bufWriter.Flush()
+	return nil
+}
+
+// createFile creates a .flow file to save messages and timeouts on the predifined location
+func (r *replayMessagePersister) createFile(filePrefix string) (*os.File, error) {
+	if _, err := os.Stat(directoryPath); os.IsNotExist(err) {
+		err := os.Mkdir(directoryPath, 0777)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	path, err := filepath.Abs(directoryPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if r.timestamp == "" {
+		r.timestamp = time.Now().Format(time.RFC3339)
+	}
+
+	file, err := os.OpenFile(filepath.Join(path, fmt.Sprintf("%v_%v.flow", filePrefix, r.timestamp)), os.O_RDWR|os.O_APPEND|os.O_CREATE, 0660)
+	if err != nil {
+		return nil, err
+	}
+
+	return file, err
+}
+
+// closeFile closes file created by the ReplayMessagesHandler if it is open
+func (r *replayMessagePersister) closeFile() error {
+	var errStrings []string
+	if r.messagesFile != nil {
+		if err := r.messagesFile.Close(); err != nil {
+			errStrings = append(errStrings, err.Error())
+		}
+	}
+
+	if r.metaDataFile != nil {
+		if err := r.metaDataFile.Close(); err != nil {
+			errStrings = append(errStrings, err.Error())
+		}
+	}
+
+	if len(errStrings) > 0 {
+		return fmt.Errorf(strings.Join(errStrings, "\n"))
+	}
+
 	return nil
 }

--- a/e2e/fuzz/replay/replay_message_persister.go
+++ b/e2e/fuzz/replay/replay_message_persister.go
@@ -168,23 +168,24 @@ func (r *replayMessagePersister) writeToFile(data [][]byte, bufWriter *bufio.Wri
 
 // createFile creates a .flow file to save messages and timeouts on the predifined location
 func (r *replayMessagePersister) createFile(filePrefix string) (*os.File, error) {
-	if _, err := os.Stat(directoryPath); os.IsNotExist(err) {
-		err := os.Mkdir(directoryPath, 0777)
+	if r.timestamp == "" {
+		r.timestamp = time.Now().Format(time.RFC3339)
+	}
+
+	directory := fmt.Sprintf("%v_%v", directoryPath, r.timestamp)
+	if _, err := os.Stat(directory); os.IsNotExist(err) {
+		err := os.Mkdir(directory, 0777)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	path, err := filepath.Abs(directoryPath)
+	path, err := filepath.Abs(directory)
 	if err != nil {
 		return nil, err
 	}
 
-	if r.timestamp == "" {
-		r.timestamp = time.Now().Format(time.RFC3339)
-	}
-
-	file, err := os.OpenFile(filepath.Join(path, fmt.Sprintf("%v_%v.flow", filePrefix, r.timestamp)), os.O_RDWR|os.O_APPEND|os.O_CREATE, 0660)
+	file, err := os.OpenFile(filepath.Join(path, fmt.Sprintf("%v.flow", filePrefix)), os.O_RDWR|os.O_APPEND|os.O_CREATE, 0660)
 	if err != nil {
 		return nil, err
 	}

--- a/e2e/fuzz/replay/replay_message_reader.go
+++ b/e2e/fuzz/replay/replay_message_reader.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/0xPolygon/pbft-consensus"
@@ -26,8 +27,14 @@ type replayMessageReader struct {
 }
 
 // openFiles opens the .flow files on provided location
-func (r *replayMessageReader) openFiles(messagesFilePath, metaDataFilePath string) error {
-	_, err := os.Stat(messagesFilePath)
+func (r *replayMessageReader) openFiles(filesDirectory string) error {
+	_, err := os.Stat(filesDirectory)
+	if err != nil {
+		return err
+	}
+
+	messagesFilePath := filepath.Join(filesDirectory, fmt.Sprintf("%v.flow", MessagesFilePrefix))
+	_, err = os.Stat(messagesFilePath)
 	if err != nil {
 		return err
 	}
@@ -37,6 +44,7 @@ func (r *replayMessageReader) openFiles(messagesFilePath, metaDataFilePath strin
 		return err
 	}
 
+	metaDataFilePath := filepath.Join(filesDirectory, fmt.Sprintf("%v.flow", MetaDataFilePrefix))
 	_, err = os.Stat(metaDataFilePath)
 	if err != nil {
 		return err

--- a/e2e/fuzz/replay/replay_message_reader.go
+++ b/e2e/fuzz/replay/replay_message_reader.go
@@ -97,17 +97,17 @@ func (r *replayMessageReader) readNodeMetaData(nodeExecutionHandler *replayNodeE
 		return nil, err
 	}
 
-	nodeExecutionHandler.dropNodeActions = make(map[pbft.NodeID]map[uint64]*e2e.MetaData, nodeCount)
-	nodeExecutionHandler.revertDropNodeActions = make(map[pbft.NodeID]map[uint64]*e2e.MetaData, nodeCount)
-	nodeExecutionHandler.lastSequencesByNode = make(map[pbft.NodeID]*e2e.MetaData, nodeCount)
+	nodeExecutionHandler.dropNodeActions = make(map[pbft.NodeID]map[uint64]*MetaData, nodeCount)
+	nodeExecutionHandler.revertDropNodeActions = make(map[pbft.NodeID]map[uint64]*MetaData, nodeCount)
+	nodeExecutionHandler.lastSequencesByNode = make(map[pbft.NodeID]*MetaData, nodeCount)
 
 	for _, name := range nodeNames {
-		nodeExecutionHandler.dropNodeActions[pbft.NodeID(name)] = make(map[uint64]*e2e.MetaData)
-		nodeExecutionHandler.revertDropNodeActions[pbft.NodeID(name)] = make(map[uint64]*e2e.MetaData)
+		nodeExecutionHandler.dropNodeActions[pbft.NodeID(name)] = make(map[uint64]*MetaData)
+		nodeExecutionHandler.revertDropNodeActions[pbft.NodeID(name)] = make(map[uint64]*MetaData)
 	}
 
 	for scanner.Scan() {
-		var action *e2e.MetaData
+		var action *MetaData
 		if err := json.Unmarshal(scanner.Bytes(), &action); err != nil {
 			log.Printf("[ERROR] Error happened on unmarshalling action in .flow file. Reason: %v", err)
 			return nodeNames, err

--- a/e2e/fuzz/replay/replay_messages_notifier.go
+++ b/e2e/fuzz/replay/replay_messages_notifier.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/0xPolygon/pbft-consensus"
-	"github.com/0xPolygon/pbft-consensus/e2e"
 )
 
 const (
@@ -34,8 +33,8 @@ func NewReplayMessagesNotifierForReplay(nodeExecutionHandler *replayNodeExecutio
 }
 
 // SaveMetaData saves node meta data to .flow file
-func (r *ReplayMessagesNotifier) SaveMetaData(nodeNames []string, lastSequences []*e2e.MetaData) error {
-	return r.messagePersister.saveMetaData(nodeNames, lastSequences)
+func (r *ReplayMessagesNotifier) SaveMetaData(nodeNames []string) error {
+	return r.messagePersister.saveMetaData(nodeNames)
 }
 
 // SaveState saves currently cached messages and timeouts to .flow file
@@ -60,6 +59,7 @@ func (r *ReplayMessagesNotifier) ReadNextMessage(p *pbft.Pbft, timeoutChannel ch
 	if r.nodeExectionHandler != nil {
 		validatorId := p.GetValidatorId()
 		if msg != nil {
+			r.nodeExectionHandler.checkForNodesToBeRestarted(msg.View.Sequence)
 			if r.nodeExectionHandler.checkIsTimeout(validatorId, msg, timeoutChannel) {
 				return nil, nil
 			}
@@ -83,6 +83,6 @@ func (r *ReplayMessagesNotifier) CreateTimeoutChannel(timeout time.Duration) cha
 }
 
 // HandleAction is an implementation of ReplayMessageNotifier interface
-func (r *ReplayMessagesNotifier) HandleAction(action *e2e.MetaData) {
-	r.messagePersister.addAction(action)
+func (r *ReplayMessagesNotifier) HandleAction(actionType, data string, sequence, round uint64) {
+	r.messagePersister.addAction(NewMetaData(actionType, data, sequence, round))
 }

--- a/e2e/fuzz/replay/replay_node_execution.go
+++ b/e2e/fuzz/replay/replay_node_execution.go
@@ -1,0 +1,153 @@
+package replay
+
+import (
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/0xPolygon/pbft-consensus"
+	"github.com/0xPolygon/pbft-consensus/e2e"
+)
+
+// replayNodeExecutionHandler handles the simulation of actions and
+type replayNodeExecutionHandler struct {
+	actionLock            sync.Mutex
+	nodesExecutionLock    sync.Mutex
+	lastSequencesByNode   map[pbft.NodeID]*e2e.MetaData
+	dropNodeActions       map[pbft.NodeID]map[uint64]*e2e.MetaData
+	revertDropNodeActions map[pbft.NodeID]map[uint64]*e2e.MetaData
+	nodesDoneWithExection map[pbft.NodeID]bool
+	dropedNodes           map[pbft.NodeID]uint64
+	cluster               *e2e.Cluster
+	msgExecutionDone      chan string
+	dropNode              chan string
+}
+
+// NewNodeExecutionHandler creates a new replayNodeExecutionHandler
+func NewNodeExecutionHandler() *replayNodeExecutionHandler {
+	return &replayNodeExecutionHandler{
+		dropedNodes:      make(map[pbft.NodeID]uint64),
+		msgExecutionDone: make(chan string),
+		dropNode:         make(chan string),
+	}
+}
+
+// startActionSimulation starts the cluster and simulates fuzz actions in replay that were saved in meta data file
+func (r *replayNodeExecutionHandler) startActionSimulation(cluster *e2e.Cluster) {
+	r.cluster = cluster
+	revertTicker := time.NewTicker(10 * time.Millisecond)
+	nodesCount := len(cluster.GetNodes())
+	r.nodesDoneWithExection = make(map[pbft.NodeID]bool, nodesCount)
+	stoppedNodes := make(map[string]bool, nodesCount)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		maxHeight := uint64(0)
+		for {
+			select {
+			case <-revertTicker.C:
+				currentMaxHeight := cluster.GetMaxHeight() + 1
+				if maxHeight < currentMaxHeight {
+					maxHeight = currentMaxHeight
+				}
+				r.checkForNodesToBeRestarted(maxHeight, cluster)
+			case nodeDone := <-r.msgExecutionDone:
+				cluster.StopNode(nodeDone)
+				stoppedNodes[nodeDone] = true
+				if len(stoppedNodes) == nodesCount {
+					wg.Done()
+					return
+				}
+			case nodeToDrop := <-r.dropNode:
+				cluster.StopNode(nodeToDrop)
+			default:
+				continue
+			}
+		}
+	}()
+
+	cluster.Start()
+	wg.Wait()
+}
+
+// stopActionSimulation stops the cluster and replay execution
+func (r *replayNodeExecutionHandler) stopActionSimulation(cluster *e2e.Cluster) {
+	cluster.Stop()
+}
+
+// checkIfDoneWithExecution checks if node finished with processing all the messages from .flow file
+func (r *replayNodeExecutionHandler) checkIfDoneWithExecution(validatorId pbft.NodeID, sequence, round uint64) bool {
+	lastSequence := r.lastSequencesByNode[validatorId]
+	if sequence > lastSequence.Sequence ||
+		(sequence == lastSequence.Sequence && round == lastSequence.Round) {
+		r.nodesExecutionLock.Lock()
+		defer r.nodesExecutionLock.Unlock()
+
+		if _, isDone := r.nodesDoneWithExection[validatorId]; !isDone {
+			r.nodesDoneWithExection[validatorId] = true
+			r.msgExecutionDone <- string(validatorId)
+		}
+		return true
+	}
+
+	return false
+}
+
+// checkForNodesToBeRestarted checks if any node need to be restarted when a certain sequence is reached
+func (r *replayNodeExecutionHandler) checkForNodesToBeRestarted(sequence uint64, cluster *e2e.Cluster) {
+	r.actionLock.Lock()
+	defer r.actionLock.Unlock()
+
+	for node, sequenceDroped := range r.dropedNodes {
+		if _, hasSequence := r.revertDropNodeActions[node][sequence]; hasSequence && sequence >= sequenceDroped {
+			log.Printf("[REPLAY] Restarting node: %v in sequence: %v.\n", node, sequence)
+			delete(r.dropedNodes, node)
+			cluster.StartNode(string(node))
+		}
+	}
+}
+
+// checkIsTimeout checks if a message is a timeout and triggers the timeout channel of provided validator
+func (r *replayNodeExecutionHandler) checkIsTimeout(validatorId pbft.NodeID, msg *pbft.MessageReq, timeoutChannel chan time.Time) bool {
+	if isTimeoutMessage(msg) {
+		go func() {
+			log.Printf("[REPLAY] A timeout occurred in node: %v, sequence: %v, round: %v.\n", validatorId, msg.View.Sequence, msg.View.Round)
+			timeoutChannel <- time.Now()
+		}()
+		return true
+	}
+
+	return false
+}
+
+// checkIfShouldDrop checks if node should be dropped or stopped in given sequence and round
+func (r *replayNodeExecutionHandler) checkIfShouldDrop(validatorId pbft.NodeID, view *pbft.View, timeoutChannel chan time.Time) {
+	if _, exists := r.dropNodeActions[validatorId][view.Sequence]; exists {
+		log.Printf("[REPLAY] Dropping node: %v in sequence: %v.\n", validatorId, view.Sequence)
+		r.nodesExecutionLock.Lock()
+		defer r.nodesExecutionLock.Unlock()
+
+		if r.lastSequencesByNode[validatorId].Sequence <= view.Sequence {
+			// it is dropped in the last sequence, there is no messages for it after this point, so it is done with execution
+			if _, isDone := r.nodesDoneWithExection[validatorId]; !isDone {
+				r.nodesDoneWithExection[validatorId] = true
+				r.msgExecutionDone <- string(validatorId)
+			}
+		} else {
+			r.dropedNodes[validatorId] = view.Sequence
+			r.dropNode <- string(validatorId)
+		}
+	} else {
+		if !r.checkIfDoneWithExecution(validatorId, view.Sequence, view.Round) {
+			panic(fmt.Sprintf("node: %v is incorrect state in replay. It should be either dropped or done.", validatorId))
+		}
+	}
+}
+
+// isTimeoutMessage checks if message in .flow file represents a timeout
+func isTimeoutMessage(message *pbft.MessageReq) bool {
+	return message.Hash == nil && message.Proposal == nil && message.Seal == nil && message.From == ""
+}

--- a/e2e/fuzz/runner.go
+++ b/e2e/fuzz/runner.go
@@ -108,6 +108,8 @@ func validateNodes(c *e2e.Cluster) {
 			for _, n := range c.Nodes() {
 				log.Printf("Node: %v, running: %v, locked: %v, height: %v, proposal: %v\n", n.GetName(), n.IsRunning(), n.IsLocked(), n.GetNodeHeight(), n.GetProposal())
 			}
+
+			c.SaveState()
 			panic("Desired height not reached.")
 		}
 		log.Println("Cluster validation done.")


### PR DESCRIPTION
Replay messages feature now saves actions that occurred in fuzz run to a separate .flow file so that they can be simulated on replay as well. For now, only Drop Node actions are saved to .flow file and simulated in replay.

When running `fuzz-run` command, messages are saved to `messages.flow` file, but other meta data (node names, actions, last sequences) are saved to `metaData.flow` file inside the **SavedState** folder.

`metaData.flow` file contains data about:

- node names - name of nodes that were created on cluster.
- last sequences in which node were when cluster was stopped - this is needed for replay to know exactly when to stop node from executing in replay (this way we now, that the node reached its end and it needs to be stopped).
- actions - data about drop node actions that occurred in fuzz run, as well as their revert actions.

Look of `messages.flow` file remains the same. `metaData.flow` file, looks as follows:
```
["NODE_0","NODE_1","NODE_2","NODE_3","NODE_4"]
{"actionType":"LastSequence","data":"NODE_0","sequence":10,"round":0}
{"actionType":"LastSequence","data":"NODE_1","sequence":11,"round":0}
{"actionType":"LastSequence","data":"NODE_2","sequence":11,"round":0}
{"actionType":"LastSequence","data":"NODE_3","sequence":11,"round":0}
{"actionType":"LastSequence","data":"NODE_4","sequence":11,"round":0}
{"actionType":"DropNode","data":"NODE_3","sequence":5,"round":0}
{"actionType":"RevertDropNode","data":"NODE_3","sequence":6,"round":0}
```
`MetaData` struct is used to store all necessary data to `metaData.flow` file. On loading the given file, based on `actionType` property, replay knows in which map to store a given action.

`replay-messages` command is now changed to receive folder path where `messages.flow` and to `metaData.flow` files are stored, e.g:
`go run ./e2e/fuzz/cmd/main.go replay-messages -filesDirectory=../SavedData`

**NOTE**: both files are needed for replay to execute.

Simulating node actions and stopping nodes when they are done with execution is now handled in `replay_node_execution.go`.
Once replay is started, when node reads its next message from queue, it can now recognize if it needs to shut down properly or if it needs to simulate a drop. 
We know that a node needs to be stopped when it has nothing to read from the queue and it reached the sequence and round that is defined in its `LastSequence` in `metaData.flow` file.
We know that a node needs to be dropped if it has nothing to read from the queue for given sequence and round, but given sequence and round are not the same as the one defined in its `LastSequence` in `metaData.flow` file.

`replayNodeExecutionHandler` starts a go routine before starting the cluster that listens if a node needs to be dropped, or if its done with execution, or if it needs to be restarted when a sequence is reached in cluster that corresponds to sequence in which node drop was reverted as defined in `RevertNode` action in `metaData.flow` file.

Once all nodes are done with execution, `replayNodeExecutionHandler` will stop the cluster, and command will exit.

