### PR TITLE
PBFT liveness issue tests

### DIFF
--- a/e2e/e2e_partition_test.go
+++ b/e2e/e2e_partition_test.go
@@ -21,6 +21,8 @@ import (
 // it routes messages only to specific nodes and induces that nodes lock on different proposal.
 // In the round=1, it marks one node as faulty (meaning that it doesn't takes part in gossiping).
 func TestE2E_Partition_LivenessIssue_Case1_FiveNodes_OneFaulty(t *testing.T) {
+	t.Parallel()
+
 	round0 := roundMetadata{
 		round: 0,
 		// induce locking A_3 and A_4 on one proposal
@@ -80,7 +82,7 @@ func TestE2E_Partition_LivenessIssue_Case1_FiveNodes_OneFaulty(t *testing.T) {
 	c.Start()
 	defer c.Stop()
 
-	err := c.WaitForHeight(3, 5*time.Minute, []string{"A_0", "A_2", "A_3", "A_4"})
+	err := c.WaitForHeight(3, 1*time.Minute, []string{"A_0", "A_2", "A_3", "A_4"})
 
 	if err != nil {
 		// log to check what is the end state
@@ -94,7 +96,8 @@ func TestE2E_Partition_LivenessIssue_Case1_FiveNodes_OneFaulty(t *testing.T) {
 		}
 	}
 
-	assert.NoError(t, err)
+	// TODO: Temporary assertion until liveness issue is resolved (after fix is merged we need to revert back to assert.NoError(t, err))
+	assert.Error(t, err)
 }
 
 // Test proves existence of liveness issues which is described in
@@ -108,6 +111,8 @@ func TestE2E_Partition_LivenessIssue_Case1_FiveNodes_OneFaulty(t *testing.T) {
 // it routes messages only to specific nodes and induces that nodes lock on different proposal.
 // In the round=3, it marks one node as faulty (meaning that it doesn't takes part in gossiping).
 func TestE2E_Partition_LivenessIssue_Case2_SixNodes_OneFaulty(t *testing.T) {
+	t.Parallel()
+
 	round0 := roundMetadata{
 		round: 0,
 		// lock A_1, A_4
@@ -180,7 +185,7 @@ func TestE2E_Partition_LivenessIssue_Case2_SixNodes_OneFaulty(t *testing.T) {
 	c.Start()
 	defer c.Stop()
 
-	err := c.WaitForHeight(3, 5*time.Minute, []string{"A_0", "A_1", "A_3", "A_4", "A_5"})
+	err := c.WaitForHeight(3, 1*time.Minute, []string{"A_0", "A_1", "A_3", "A_4", "A_5"})
 
 	if err != nil {
 		// log to check what is the end state
@@ -194,7 +199,8 @@ func TestE2E_Partition_LivenessIssue_Case2_SixNodes_OneFaulty(t *testing.T) {
 		}
 	}
 
-	assert.NoError(t, err)
+	// TODO: Temporary assertion until liveness issue is resolved (after fix is merged we need to revert back to assert.NoError(t, err))
+	assert.Error(t, err)
 }
 
 func TestE2E_Partition_OneMajority(t *testing.T) {

--- a/e2e/e2e_partition_test.go
+++ b/e2e/e2e_partition_test.go
@@ -80,11 +80,18 @@ func TestE2E_Partition_LivenessIssue_Case1_FiveNodes_OneFaulty(t *testing.T) {
 	c.Start()
 	defer c.Stop()
 
-	err := c.WaitForHeight(3, 5*time.Minute)
+	err := c.WaitForHeight(3, 5*time.Minute, []string{"A_0", "A_2", "A_3", "A_4"})
 
-	// log to check what is the end state
-	for _, n := range c.nodes {
-		t.Logf("Node %v, isProposalLocked: %v, proposal data: %v\n", n.name, n.pbft.IsLocked(), n.pbft.GetProposal().Data)
+	if err != nil {
+		// log to check what is the end state
+		for _, n := range c.nodes {
+			proposal := n.pbft.GetProposal()
+			if proposal != nil {
+				t.Logf("Node %v, isProposalLocked: %v, proposal data: %v\n", n.name, n.pbft.IsLocked(), proposal.Data)
+			} else {
+				t.Logf("Node %v, isProposalLocked: %v, no proposal set\n", n.name, n.pbft.IsLocked())
+			}
+		}
 	}
 
 	assert.NoError(t, err)
@@ -164,15 +171,27 @@ func TestE2E_Partition_LivenessIssue_Case2_SixNodes_OneFaulty(t *testing.T) {
 
 	transport.withFlowMap(flowMap).withGossipHandler(livenessGossipHandler)
 
-	c := newPBFTCluster(t, "liveness_issue", "A", nodesCnt, transport)
+	config := &ClusterConfig{
+		Name:   "liveness_issue",
+		Prefix: "A",
+		Count:  nodesCnt,
+	}
+	c := NewPBFTCluster(t, config, transport)
 	c.Start()
 	defer c.Stop()
 
-	err := c.WaitForHeight(3, 1*time.Minute)
+	err := c.WaitForHeight(3, 5*time.Minute, []string{"A_0", "A_1", "A_3", "A_4", "A_5"})
 
-	// log to check what is the end state
-	for _, n := range c.nodes {
-		t.Logf("Node %v, isProposalLocked: %v, proposal data: %v\n", n.name, n.pbft.IsStateLocked(), n.pbft.GetProposal().Data)
+	if err != nil {
+		// log to check what is the end state
+		for _, n := range c.nodes {
+			proposal := n.pbft.GetProposal()
+			if proposal != nil {
+				t.Logf("Node %v, isProposalLocked: %v, proposal data: %v\n", n.name, n.pbft.IsLocked(), proposal.Data)
+			} else {
+				t.Logf("Node %v, isProposalLocked: %v, no proposal set\n", n.name, n.pbft.IsLocked())
+			}
+		}
 	}
 
 	assert.NoError(t, err)

--- a/e2e/e2e_partition_test.go
+++ b/e2e/e2e_partition_test.go
@@ -21,7 +21,6 @@ import (
 // it routes messages only to specific nodes and induces that nodes lock on different proposal.
 // In the round=1, it marks one node as faulty (meaning that it doesn't takes part in gossiping).
 func TestE2E_Partition_LivenessIssue_Case1_FiveNodes_OneFaulty(t *testing.T) {
-	const nodesCnt = 5
 	round0 := roundMetadata{
 		round: 0,
 		// induce locking A_3 and A_4 on one proposal
@@ -72,10 +71,11 @@ func TestE2E_Partition_LivenessIssue_Case1_FiveNodes_OneFaulty(t *testing.T) {
 	transport.withFlowMap(flowMap).withGossipHandler(livenessGossipHandler)
 
 	config := &ClusterConfig{
+		Count:  5,
 		Name:   "liveness_issue",
 		Prefix: "A",
-		Count:  nodesCnt,
 	}
+
 	c := NewPBFTCluster(t, config, transport)
 	c.Start()
 	defer c.Stop()
@@ -108,7 +108,6 @@ func TestE2E_Partition_LivenessIssue_Case1_FiveNodes_OneFaulty(t *testing.T) {
 // it routes messages only to specific nodes and induces that nodes lock on different proposal.
 // In the round=3, it marks one node as faulty (meaning that it doesn't takes part in gossiping).
 func TestE2E_Partition_LivenessIssue_Case2_SixNodes_OneFaulty(t *testing.T) {
-	const nodesCnt = 6
 	round0 := roundMetadata{
 		round: 0,
 		// lock A_1, A_4
@@ -172,10 +171,11 @@ func TestE2E_Partition_LivenessIssue_Case2_SixNodes_OneFaulty(t *testing.T) {
 	transport.withFlowMap(flowMap).withGossipHandler(livenessGossipHandler)
 
 	config := &ClusterConfig{
+		Count:  6,
 		Name:   "liveness_issue",
 		Prefix: "A",
-		Count:  nodesCnt,
 	}
+
 	c := NewPBFTCluster(t, config, transport)
 	c.Start()
 	defer c.Stop()

--- a/e2e/e2e_partition_test.go
+++ b/e2e/e2e_partition_test.go
@@ -6,8 +6,89 @@ import (
 	"testing"
 	"time"
 
+	"github.com/0xPolygon/pbft-consensus"
 	"github.com/stretchr/testify/assert"
 )
+
+// Test proves existence of liveness issues which is described in
+// Correctness Analysis of Istanbul Byzantine Fault Tolerance (https://arxiv.org/pdf/1901.07160.pdf).
+// Specific problem this test is emulating is described in Chapter 7.1, Case 1.
+// Summary of the problem is that there are not enough nodes to lock on single proposal,
+// due to some issues where nodes being unable to deliver messages to all of the peers.
+// Therefore nodes are split into two subsets locked on different proposals.
+// Simulating one node from larger subset as faulty one, results in being unable to reach a consensus on a single proposal and that's what liveness issue is about.
+// This test creates a single cluster of 5 nodes, but instead of letting all the peers communicate with each other,
+// it routes messages only to specific nodes and induces that nodes lock on different proposal.
+// In the round=1, it marks one node as faulty (meaning that it doesn't takes part in gossiping).
+func TestE2E_Partition_Liveness(t *testing.T) {
+	const nodesCnt = 5
+	round0 := roundMetadata{
+		round: 0,
+		// induce locking A_3 and A_4 on one proposal
+		routingMap: map[sender]receivers{
+			"A_0": {"A_3", "A_4"},
+			"A_3": {"A_0", "A_3", "A_4"},
+			"A_4": {"A_3", "A_4"},
+		},
+	}
+	round1 := roundMetadata{
+		round: 1,
+		// induce locking lock A_0 and A_2 on another proposal
+		routingMap: map[sender]receivers{
+			"A_0": {"A_0", "A_2", "A_3", "A_4"},
+			"A_1": {"A_0", "A_2", "A_3", "A_4"},
+			"A_2": {"A_0", "A_1", "A_2", "A_3", "A_4"},
+
+			"A_3": {"A_0", "A_1", "A_2", "A_3", "A_4"},
+			"A_4": {"A_0", "A_1", "A_2", "A_3", "A_4"},
+		},
+	}
+	flowMap := map[uint64]roundMetadata{0: round0, 1: round1}
+
+	faultyNodeId := pbft.NodeID("A_1")
+
+	transport := newGenericGossipTransport()
+	// If livenessGossipHandler returns false, message should not be transported.
+	livenessGossipHandler := func(senderId, receiverId pbft.NodeID, msg *pbft.MessageReq) bool {
+		if msg.View.Round > 1 || msg.View.Sequence > 2 {
+			// Faulty node is unresponsive after round 1, and all the other nodes are gossiping all the messages.
+			return senderId != faultyNodeId && receiverId != faultyNodeId
+		} else {
+			if msg.View.Round <= 1 && msg.Type == pbft.MessageReq_Commit {
+				// Cut all the commit messages gossiping for round 0 and 1
+				return false
+			}
+			if msg.View.Round == 1 && senderId == faultyNodeId &&
+				(msg.Type == pbft.MessageReq_RoundChange || msg.Type == pbft.MessageReq_Commit) {
+				// Case where we are in round 1 and 2 different nodes will lock the proposal
+				// (consequence of faulty node doesn't gossip round change and commit messages).
+				return false
+			}
+		}
+
+		return transport.shouldGossipBasedOnMsgFlowMap(msg, senderId, receiverId)
+	}
+
+	transport.withFlowMap(flowMap).withGossipHandler(livenessGossipHandler)
+
+	config := &ClusterConfig{
+		Name:   "liveness_issue",
+		Prefix: "A",
+		Count:  nodesCnt,
+	}
+	c := NewPBFTCluster(t, config, transport)
+	c.Start()
+	defer c.Stop()
+
+	err := c.WaitForHeight(3, 5*time.Minute)
+
+	// log to check what is the end state
+	for _, n := range c.nodes {
+		t.Logf("Node %v, isProposalLocked: %v, proposal data: %v\n", n.name, n.pbft.IsLocked(), n.pbft.GetProposal().Data)
+	}
+
+	assert.NoError(t, err)
+}
 
 func TestE2E_Partition_OneMajority(t *testing.T) {
 	t.Parallel()

--- a/e2e/e2e_partition_test.go
+++ b/e2e/e2e_partition_test.go
@@ -20,7 +20,7 @@ import (
 // This test creates a single cluster of 5 nodes, but instead of letting all the peers communicate with each other,
 // it routes messages only to specific nodes and induces that nodes lock on different proposal.
 // In the round=1, it marks one node as faulty (meaning that it doesn't takes part in gossiping).
-func TestE2E_Partition_Liveness(t *testing.T) {
+func TestE2E_Partition_LivenessIssue_Case1_FiveNodes_OneFaulty(t *testing.T) {
 	const nodesCnt = 5
 	round0 := roundMetadata{
 		round: 0,
@@ -85,6 +85,94 @@ func TestE2E_Partition_Liveness(t *testing.T) {
 	// log to check what is the end state
 	for _, n := range c.nodes {
 		t.Logf("Node %v, isProposalLocked: %v, proposal data: %v\n", n.name, n.pbft.IsLocked(), n.pbft.GetProposal().Data)
+	}
+
+	assert.NoError(t, err)
+}
+
+// Test proves existence of liveness issues which is described in
+// Correctness Analysis of Istanbul Byzantine Fault Tolerance(https://arxiv.org/pdf/1901.07160.pdf).
+// Specific problem this test is emulating is described in Chapter 7.1, Case 2.
+// Summary of the problem is that there are not enough nodes to lock on single proposal,
+// due to some issues where nodes being unable to deliver messages to all of the peers.
+// When there are (nh) = 6 nodes, and they are split into three subsets, all locked on different proposals, where one of the nodes becomes faulty,
+// nodes are unable to reach a consensus on a single proposal, resulting in continuous RoundChange.
+// This test creates a single cluster of 6 nodes, but instead of letting all the peers communicate with each other,
+// it routes messages only to specific nodes and induces that nodes lock on different proposal.
+// In the round=3, it marks one node as faulty (meaning that it doesn't takes part in gossiping).
+func TestE2E_Partition_LivenessIssue_Case2_SixNodes_OneFaulty(t *testing.T) {
+	const nodesCnt = 6
+	round0 := roundMetadata{
+		round: 0,
+		// lock A_1, A_4
+		routingMap: map[sender]receivers{
+			"A_0": {"A_1", "A_3", "A_4"},
+			"A_3": {"A_1", "A_3", "A_4"},
+			"A_4": {"A_1", "A_4"},
+		},
+	}
+
+	round2 := roundMetadata{
+		round: 2,
+		// lock A_5
+		routingMap: map[sender]receivers{
+			"A_0": {"A_5", "A_2", "A_4"},
+			"A_1": {"A_5", "A_0"},
+			"A_2": {"A_5", "A_3"},
+			"A_3": {"A_5"},
+			"A_4": {"A_5"},
+		},
+	}
+
+	round3 := roundMetadata{
+		round: 3,
+		// lock A_3 and A_0 on one proposal and A_2 will be faulty
+		routingMap: map[sender]receivers{
+			"A_3": {"A_0", "A_2", "A_3", "A_4"},
+			"A_0": {"A_0", "A_3", "A_4"},
+			"A_2": {"A_0", "A_1", "A_3", "A_4"},
+		},
+	}
+	flowMap := map[uint64]roundMetadata{0: round0, 2: round2, 3: round3}
+	transport := newGenericGossipTransport()
+	faultyNodeId := pbft.NodeID("A_2")
+
+	// If livenessGossipHandler returns false, message should not be transported.
+	livenessGossipHandler := func(senderId, receiverId pbft.NodeID, msg *pbft.MessageReq) (sent bool) {
+		if msg.View.Round == 1 && msg.Type == pbft.MessageReq_RoundChange {
+			return true
+		}
+
+		if msg.View.Round > 3 || msg.View.Sequence > 2 {
+			// Faulty node is unresponsive after round 3, and all the other nodes are gossiping all the messages.
+			return senderId != faultyNodeId && receiverId != faultyNodeId
+		} else {
+			if msg.View.Round <= 1 && msg.Type == pbft.MessageReq_Commit {
+				// Cut all the commit messages gossiping for round 0 and 1
+				return false
+			}
+			if msg.View.Round == 3 && senderId == faultyNodeId &&
+				(msg.Type == pbft.MessageReq_RoundChange || msg.Type == pbft.MessageReq_Commit) {
+				// Case where we are in round 3 and 2 different nodes will lock the proposal
+				// (consequence of faulty node doesn't gossip round change and commit messages).
+				return false
+			}
+		}
+
+		return transport.shouldGossipBasedOnMsgFlowMap(msg, senderId, receiverId)
+	}
+
+	transport.withFlowMap(flowMap).withGossipHandler(livenessGossipHandler)
+
+	c := newPBFTCluster(t, "liveness_issue", "A", nodesCnt, transport)
+	c.Start()
+	defer c.Stop()
+
+	err := c.WaitForHeight(3, 1*time.Minute)
+
+	// log to check what is the end state
+	for _, n := range c.nodes {
+		t.Logf("Node %v, isProposalLocked: %v, proposal data: %v\n", n.name, n.pbft.IsStateLocked(), n.pbft.GetProposal().Data)
 	}
 
 	assert.NoError(t, err)

--- a/e2e/framework.go
+++ b/e2e/framework.go
@@ -688,6 +688,7 @@ func (v *valString) CalcProposer(round uint64) pbft.NodeID {
 	}
 
 	pick := seed % uint64(v.Len())
+
 	return (v.nodes)[pick]
 }
 

--- a/e2e/transport.go
+++ b/e2e/transport.go
@@ -65,6 +65,91 @@ type transportHook interface {
 	GetPartitions() map[string][]string
 }
 
+type sender pbft.NodeID
+type receivers []pbft.NodeID
+
+// Encapsulates message routing for certain round
+type roundMetadata struct {
+	round      uint64
+	routingMap map[sender]receivers
+}
+
+// Callback which enables determining which message should be gossiped
+type gossipHandler func(sender, receiver pbft.NodeID, msg *pbft.MessageReq) bool
+
+// Transport implementation which enables specifying custom gossiping logic
+type genericGossipTransport struct {
+	flowMap       map[uint64]roundMetadata
+	gossipHandler gossipHandler
+}
+
+// Initialize new generic gossip transport
+func newGenericGossipTransport() *genericGossipTransport {
+	defaultGossipHandler := func(sender, receiver pbft.NodeID, msg *pbft.MessageReq) bool {
+		return true
+	}
+	return &genericGossipTransport{
+		flowMap:       make(map[uint64]roundMetadata),
+		gossipHandler: defaultGossipHandler,
+	}
+}
+
+// Function which attaches gossip handler
+func (t *genericGossipTransport) withGossipHandler(gossipHandler gossipHandler) *genericGossipTransport {
+	t.gossipHandler = gossipHandler
+	return t
+}
+
+// Function which sets message routing per round mapping
+func (t *genericGossipTransport) withFlowMap(flowMap map[uint64]roundMetadata) *genericGossipTransport {
+	t.flowMap = flowMap
+	return t
+}
+
+// Function determining whether a message should be gossiped, based on provided flow map, which describes messages routing per round.
+func (t *genericGossipTransport) shouldGossipBasedOnMsgFlowMap(msg *pbft.MessageReq, senderId pbft.NodeID, receiverId pbft.NodeID) bool {
+	roundMedatada, ok := t.flowMap[msg.View.Round]
+	if !ok {
+		return false
+	}
+
+	if roundMedatada.round == msg.View.Round {
+		receivers, ok := roundMedatada.routingMap[sender(senderId)]
+		if !ok {
+			return false
+		}
+
+		foundReceiver := false
+		for _, v := range receivers {
+			if v == receiverId {
+				foundReceiver = true
+				break
+			}
+		}
+		return foundReceiver
+	}
+	return true
+}
+
+func (t *genericGossipTransport) Gossip(from, to pbft.NodeID, msg *pbft.MessageReq) bool {
+	if t.gossipHandler != nil {
+		return t.gossipHandler(from, to, msg)
+	}
+	return true
+}
+
+func (t *genericGossipTransport) Connects(from, to pbft.NodeID) bool {
+	return true
+}
+
+func (t *genericGossipTransport) Reset() {
+	t.gossipHandler = nil
+}
+
+func (t *genericGossipTransport) GetPartitions() map[string][]string {
+	return nil
+}
+
 // latency transport
 type randomTransport struct {
 	jitterMax time.Duration
@@ -86,6 +171,7 @@ func (r *randomTransport) Gossip(from, to pbft.NodeID, msg *pbft.MessageReq) boo
 	}
 	return true
 }
+
 func (r *randomTransport) Reset() {
 	// no impl
 }

--- a/state.go
+++ b/state.go
@@ -222,6 +222,10 @@ func newState() *currentState {
 	return c
 }
 
+func (c *currentState) IsLocked() bool {
+	return c.locked
+}
+
 func (c *currentState) GetSequence() uint64 {
 	return c.view.Sequence
 }


### PR DESCRIPTION
This is a wrapper PR which merges two liveness issue integration tests, described in [Liveness correctness analysis paper, chapter 7.1](https://arxiv.org/pdf/1901.07160.pdf).