### PR TITLE
POS3-141 Sealing with node id

### DIFF
--- a/consensus.go
+++ b/consensus.go
@@ -103,7 +103,7 @@ func (c *Config) ApplyOps(opts ...ConfigOption) {
 
 type SealedProposal struct {
 	Proposal       *Proposal
-	CommittedSeals []CommitedSeal
+	CommittedSeals []CommittedSeal
 	Proposer       NodeID
 	Number         uint64
 }

--- a/consensus.go
+++ b/consensus.go
@@ -103,7 +103,7 @@ func (c *Config) ApplyOps(opts ...ConfigOption) {
 
 type SealedProposal struct {
 	Proposal       *Proposal
-	CommittedSeals [][]byte
+	CommittedSeals []CommitedSeal
 	Proposer       NodeID
 	Number         uint64
 }

--- a/state.go
+++ b/state.go
@@ -181,6 +181,14 @@ func (p *Proposal) Copy() *Proposal {
 	return pp
 }
 
+type CommitedSeal struct {
+	// Signature value
+	Signature []byte
+
+	// Node that signed
+	NodeID NodeID
+}
+
 // currentState defines the current state object in PBFT
 type currentState struct {
 	// validators represent the current validator set
@@ -237,10 +245,10 @@ func (c *currentState) GetSequence() uint64 {
 	return c.view.Sequence
 }
 
-func (c *currentState) getCommittedSeals() [][]byte {
-	committedSeals := [][]byte{}
-	for _, commit := range c.committed {
-		committedSeals = append(committedSeals, commit.Seal)
+func (c *currentState) getCommittedSeals() []CommitedSeal {
+	var committedSeals []CommitedSeal
+	for nodeId, commit := range c.committed {
+		committedSeals = append(committedSeals, CommitedSeal{Signature: commit.Seal, NodeID: nodeId})
 	}
 	return committedSeals
 }

--- a/state.go
+++ b/state.go
@@ -181,7 +181,7 @@ func (p *Proposal) Copy() *Proposal {
 	return pp
 }
 
-type CommitedSeal struct {
+type CommittedSeal struct {
 	// Signature value
 	Signature []byte
 
@@ -245,10 +245,10 @@ func (c *currentState) GetSequence() uint64 {
 	return c.view.Sequence
 }
 
-func (c *currentState) getCommittedSeals() []CommitedSeal {
-	var committedSeals []CommitedSeal
+func (c *currentState) getCommittedSeals() []CommittedSeal {
+	var committedSeals []CommittedSeal
 	for nodeId, commit := range c.committed {
-		committedSeals = append(committedSeals, CommitedSeal{Signature: commit.Seal, NodeID: nodeId})
+		committedSeals = append(committedSeals, CommittedSeal{Signature: commit.Seal, NodeID: nodeId})
 	}
 	return committedSeals
 }

--- a/state.go
+++ b/state.go
@@ -246,7 +246,7 @@ func (c *currentState) GetSequence() uint64 {
 }
 
 func (c *currentState) getCommittedSeals() []CommittedSeal {
-	var committedSeals []CommittedSeal
+	committedSeals := make([]CommittedSeal, 0, len(c.committed))
 	for nodeId, commit := range c.committed {
 		committedSeals = append(committedSeals, CommittedSeal{Signature: commit.Seal, NodeID: nodeId})
 	}

--- a/state_test.go
+++ b/state_test.go
@@ -310,35 +310,23 @@ func TestState_GetSequence(t *testing.T) {
 
 func TestState_getCommittedSeals(t *testing.T) {
 	pool := newTesterAccountPool()
-	pool.add("A", "B", "C", "D")
+	pool.add("A", "B", "C", "D", "E")
 
 	s := newState()
 	s.validators = pool.validatorSet()
 
 	s.addCommitted(createMessage("A", MessageReq_Commit))
 	s.addCommitted(createMessage("B", MessageReq_Commit))
+	s.addCommitted(createMessage("C", MessageReq_Commit))
 	committedSeals := s.getCommittedSeals()
 
-	assert.Len(t, committedSeals, 2)
-	assert.True(t, &committedSeals[0] != &s.committed["A"].Seal)
-	foundSeal := false
-	for _, seal := range committedSeals {
-		if reflect.DeepEqual(seal, s.committed["A"].Seal) {
-			foundSeal = true
-		}
+	assert.Len(t, committedSeals, 3)
+	for _, commSeal := range committedSeals {
+		el := s.committed[commSeal.NodeID]
+		assert.NotNil(t, el)
+		assert.True(t, reflect.DeepEqual(commSeal.Signature, el.Seal))
+		assert.True(t, &commSeal.Signature != &el.Seal)
 	}
-	assert.True(t, &committedSeals[0] != &s.committed["A"].Seal)
-	assert.True(t, foundSeal)
-
-	foundSeal = false
-	for _, seal := range committedSeals {
-		if reflect.DeepEqual(seal, s.committed["B"].Seal) {
-			foundSeal = true
-		}
-	}
-
-	assert.True(t, &committedSeals[1] != &s.committed["B"].Seal)
-	assert.True(t, foundSeal)
 }
 
 func TestMsgType_ToString(t *testing.T) {

--- a/state_test.go
+++ b/state_test.go
@@ -1,12 +1,12 @@
 package pbft
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	crand "crypto/rand"
 	"fmt"
 	mrand "math/rand"
-	"reflect"
 	"strconv"
 	"testing"
 	"time"
@@ -326,8 +326,8 @@ func TestState_getCommittedSeals(t *testing.T) {
 		assert.False(t, processed[commSeal.NodeID]) // all entries in committedSeals should be different
 		processed[commSeal.NodeID] = true
 		el := s.committed[commSeal.NodeID]
-		assert.NotNil(t, el)                                           // there should be entry in currentState.committed...
-		assert.True(t, reflect.DeepEqual(commSeal.Signature, el.Seal)) // ...and there signature should match
+		assert.NotNil(t, el)                                     // there should be entry in currentState.committed...
+		assert.True(t, bytes.Equal(commSeal.Signature, el.Seal)) // ...and signatures should match
 		assert.True(t, &commSeal.Signature != &el.Seal)
 	}
 }

--- a/state_test.go
+++ b/state_test.go
@@ -321,10 +321,13 @@ func TestState_getCommittedSeals(t *testing.T) {
 	committedSeals := s.getCommittedSeals()
 
 	assert.Len(t, committedSeals, 3)
+	processed := map[NodeID]bool{}
 	for _, commSeal := range committedSeals {
+		assert.False(t, processed[commSeal.NodeID]) // all entries in committedSeals should be different
+		processed[commSeal.NodeID] = true
 		el := s.committed[commSeal.NodeID]
-		assert.NotNil(t, el)
-		assert.True(t, reflect.DeepEqual(commSeal.Signature, el.Seal))
+		assert.NotNil(t, el)                                           // there should be entry in currentState.committed...
+		assert.True(t, reflect.DeepEqual(commSeal.Signature, el.Seal)) // ...and there signature should match
 		assert.True(t, &commSeal.Signature != &el.Seal)
 	}
 }

--- a/state_test.go
+++ b/state_test.go
@@ -321,10 +321,11 @@ func TestState_getCommittedSeals(t *testing.T) {
 	committedSeals := s.getCommittedSeals()
 
 	assert.Len(t, committedSeals, 3)
-	processed := map[NodeID]bool{}
+	processed := map[NodeID]struct{}{}
 	for _, commSeal := range committedSeals {
-		assert.False(t, processed[commSeal.NodeID]) // all entries in committedSeals should be different
-		processed[commSeal.NodeID] = true
+		_, exists := processed[commSeal.NodeID]
+		assert.False(t, exists) // all entries in committedSeals should be different
+		processed[commSeal.NodeID] = struct{}{}
 		el := s.committed[commSeal.NodeID]
 		assert.NotNil(t, el)                                     // there should be entry in currentState.committed...
 		assert.True(t, bytes.Equal(commSeal.Signature, el.Seal)) // ...and signatures should match


### PR DESCRIPTION
We need to expand `SealedProposal` => `CommittedSeals` to have node id, not just signature bytes