### PR TITLE
ValidateCommit extended with propsal hash

### DIFF
--- a/consensus.go
+++ b/consensus.go
@@ -131,7 +131,7 @@ type Backend interface {
 	IsStuck(num uint64) (uint64, bool)
 
 	// ValidateCommit is used to validate that a given commit is valid
-	ValidateCommit(from NodeID, seal []byte) error
+	ValidateCommit(from NodeID, seal []byte, msgHash []byte) error
 }
 
 // RoundInfo is the information about the round
@@ -459,7 +459,7 @@ func (p *Pbft) runValidateState(ctx context.Context) { // start new round
 			p.state.addPrepared(msg)
 
 		case MessageReq_Commit:
-			if err := p.backend.ValidateCommit(msg.From, msg.Seal); err != nil {
+			if err := p.backend.ValidateCommit(msg.From, msg.Seal, msg.Hash); err != nil {
 				p.logger.Printf("[ERROR]: failed to validate commit: %v", err)
 				continue
 			}

--- a/consensus_test.go
+++ b/consensus_test.go
@@ -960,7 +960,7 @@ func (m *mockBackend) HookIsStuckHandler(isStuck isStuckDelegate) *mockBackend {
 	return m
 }
 
-func (m *mockBackend) ValidateCommit(from NodeID, seal []byte) error {
+func (m *mockBackend) ValidateCommit(from NodeID, seal []byte, msgHash []byte) error {
 	return nil
 }
 

--- a/e2e/framework.go
+++ b/e2e/framework.go
@@ -666,7 +666,7 @@ func newSealedProposal(proposalData []byte, proposer pbft.NodeID, number uint64)
 func (f *Fsm) Init(*pbft.RoundInfo) {
 }
 
-func (f *Fsm) ValidateCommit(node pbft.NodeID, seal []byte) error {
+func (f *Fsm) ValidateCommit(node pbft.NodeID, seal []byte, msgHash []byte) error {
 	return nil
 }
 


### PR DESCRIPTION
ValidateCommit must be extended with proposal hash because of the BLS signing