### PR TITLE
Increase timeout on 20 minutes.

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,5 +34,5 @@ jobs:
         with:
           go-version: '1.17'
       - name: Go fuzz test
-        timeout-minutes: 10
+        timeout-minutes: 20
         run: make fuzz

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ e2e:
 	cd ./e2e && go test -v ./...
 
 fuzz:
-	cd ./e2e && go test -run TestFuzz
+	cd ./e2e && go test -timeout=20m -run TestFuzz
 
 lintci:
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.46.1


### PR DESCRIPTION
Increase timeout for fuzz tests since occasionally fails due to default 10min timeout. 