### PR TITLE
Expand RoundInfo struct with previous and current round

### DIFF
--- a/consensus_pbft.go
+++ b/consensus_pbft.go
@@ -64,9 +64,11 @@ type SealedProposal struct {
 
 // RoundInfo is the information about the round
 type RoundInfo struct {
-	IsProposer bool
-	Proposer   NodeID
-	Locked     bool
+	IsProposer    bool
+	Proposer      NodeID
+	Locked        bool
+	CurrentRound  uint64
+	PreviousRound uint64
 }
 
 // Pbft represents the PBFT consensus mechanism object

--- a/consensus_pbft.go
+++ b/consensus_pbft.go
@@ -259,9 +259,11 @@ func (p *Pbft) runAcceptState(ctx context.Context) { // start new round
 
 	isProposer := p.state.proposer == p.validator.NodeID()
 	p.backend.Init(&RoundInfo{
-		Proposer:   p.state.proposer,
-		IsProposer: isProposer,
-		Locked:     p.state.IsLocked(),
+		Proposer:      p.state.proposer,
+		IsProposer:    isProposer,
+		Locked:        p.state.IsLocked(),
+		CurrentRound:  p.state.GetCurrentRound(),
+		PreviousRound: p.state.GetPreviousRound(),
 	})
 
 	// log the current state of this span

--- a/state.go
+++ b/state.go
@@ -22,6 +22,9 @@ type state struct {
 	// Current view
 	view *View
 
+	// Previous round
+	previousRound uint64
+
 	// List of prepared messages
 	prepared map[NodeID]*MessageReq
 
@@ -215,7 +218,12 @@ func (s *state) GetCurrentRound() uint64 {
 	return atomic.LoadUint64(&s.view.Round)
 }
 
+func (s *state) GetPreviousRound() uint64 {
+	return atomic.LoadUint64(&s.previousRound)
+}
+
 func (s *state) SetCurrentRound(round uint64) {
+	atomic.StoreUint64(&s.previousRound, s.view.Round)
 	atomic.StoreUint64(&s.view.Round, round)
 }
 


### PR DESCRIPTION
Proposer calculation on v3 client depends on priority queue. We need current and previous round information provided from pbft consensus in order to know how many round elapsed in a mean time in order to make proposer calculation deterministic.