### PR TITLE
Voting power accumulation optimization

### DIFF
--- a/consensus_test.go
+++ b/consensus_test.go
@@ -816,7 +816,7 @@ func TestRoundChange_PropertyMajorityOfVotingPowerAggreement(t *testing.T) {
 			for i := range votes {
 				votesVP += stake[votes[i]]
 			}
-			return votesVP >= node.state.QuorumSize()
+			return votesVP >= node.state.getQuorumSize()
 		}).Draw(t, "Select arbitrary nodes that have majority of voting power").([]int)
 
 		for _, voterID := range votes {
@@ -978,28 +978,28 @@ func (m *mockPbft) expect(res expectResult) {
 	m.t.Helper()
 
 	if sequence := m.state.view.Sequence; sequence != res.sequence {
-		m.t.Fatalf("incorrect sequence %d %d", sequence, res.sequence)
+		m.t.Fatalf("incorrect sequence actual: %d, expected: %d", sequence, res.sequence)
 	}
 	if round := m.state.GetCurrentRound(); round != res.round {
-		m.t.Fatalf("incorrect round %d %d", round, res.round)
+		m.t.Fatalf("incorrect round actual: %d, expected: %d", round, res.round)
 	}
 	if m.getState() != res.state {
-		m.t.Fatalf("incorrect state %s %s", m.getState(), res.state)
+		m.t.Fatalf("incorrect state actual: %s, expected: %s", m.getState(), res.state)
 	}
-	if size := len(m.state.prepared); uint64(size) != res.prepareMsgs {
-		m.t.Fatalf("incorrect prepared messages %d %d", size, res.prepareMsgs)
+	if size := m.state.prepared.length(); uint64(size) != res.prepareMsgs {
+		m.t.Fatalf("incorrect prepared messages actual: %d, expected: %d", size, res.prepareMsgs)
 	}
-	if size := len(m.state.committed); uint64(size) != res.commitMsgs {
-		m.t.Fatalf("incorrect commit messages %d %d", size, res.commitMsgs)
+	if size := m.state.committed.length(); uint64(size) != res.commitMsgs {
+		m.t.Fatalf("incorrect commit messages actual: %d, expected:%d", size, res.commitMsgs)
 	}
 	if m.state.IsLocked() != res.locked {
-		m.t.Fatalf("incorrect locked %v %v", m.state.locked, res.locked)
+		m.t.Fatalf("incorrect locked actual: %v, expected: %v", m.state.locked, res.locked)
 	}
 	if size := len(m.respMsg); uint64(size) != res.outgoing {
-		m.t.Fatalf("incorrect outgoing messages %v %v", size, res.outgoing)
+		m.t.Fatalf("incorrect outgoing messages actual: %v, expected: %v", size, res.outgoing)
 	}
 	if m.state.err != res.err {
-		m.t.Fatalf("incorrect error %v %v", m.state.err, res.err)
+		m.t.Fatalf("incorrect error actual: %v, expected: %v", m.state.err, res.err)
 	}
 }
 

--- a/e2e/cluster.go
+++ b/e2e/cluster.go
@@ -104,7 +104,7 @@ func NewPBFTCluster(t *testing.T, config *ClusterConfig, hook ...transport.Hook)
 
 	for _, name := range names {
 		trace := c.tracer.Tracer(name)
-		n, _ := newPBFTNode(name, config, names, trace, tt)
+		n := newPBFTNode(name, config, names, trace, tt)
 		n.c = c
 		c.nodes[name] = n
 	}

--- a/e2e/node.go
+++ b/e2e/node.go
@@ -31,7 +31,7 @@ type node struct {
 	faulty uint64
 }
 
-func newPBFTNode(name string, clusterConfig *ClusterConfig, nodes []string, trace trace.Tracer, tt *transport.Transport) (*node, error) {
+func newPBFTNode(name string, clusterConfig *ClusterConfig, nodes []string, trace trace.Tracer, tt *transport.Transport) *node {
 	loggerOutput := helper.GetLoggerOutput(name, clusterConfig.LogsDir)
 
 	con := pbft.New(
@@ -61,7 +61,7 @@ func newPBFTNode(name string, clusterConfig *ClusterConfig, nodes []string, trac
 		running: 0,
 		// set to init index -1 so that zero value is not the same as first index
 		localSyncIndex: -1,
-	}, nil
+	}
 }
 
 func (n *node) GetName() string {

--- a/e2e/validator_set.go
+++ b/e2e/validator_set.go
@@ -47,5 +47,5 @@ func (n *ValidatorSet) Len() int {
 }
 
 func (n *ValidatorSet) VotingPower() map[pbft.NodeID]uint64 {
-	return pbft.CreateEqualWeightValidatorsMap(n.Nodes)
+	return pbft.CreateEqualVotingPowerMap(n.Nodes)
 }

--- a/state.go
+++ b/state.go
@@ -75,15 +75,6 @@ func (s *state) initializeVotingInfo() error {
 	return nil
 }
 
-// calculateVotingPower calculates voting power of provided senders
-func (s *state) calculateVotingPower(senders []NodeID) uint64 {
-	accumulatedVotingPower := uint64(0)
-	for _, nodeId := range senders {
-		accumulatedVotingPower += s.validators.VotingPower()[nodeId]
-	}
-	return accumulatedVotingPower
-}
-
 // getQuorumSize calculates quorum size (namely the number of required messages of some type in order to proceed to the next state in PBFT state machine).
 // It is calculated by formula:
 // 2 * F + 1, where F denotes maximum count of faulty nodes in order to have Byzantine fault tollerant property satisfied.

--- a/state_test.go
+++ b/state_test.go
@@ -334,36 +334,11 @@ func TestState_QuorumSize_EqualVotingPower(t *testing.T) {
 	}
 }
 
-func TestState_CalculateWeight_EqualVotingPower(t *testing.T) {
-	cases := []struct {
-		nodesCount uint
-		weight     uint64
-	}{
-		{1, 1},
-		{3, 3},
-		{4, 4},
-		{100, 100},
-	}
-
-	for _, c := range cases {
-		pool := newTesterAccountPool(int(c.nodesCount))
-		votingPower := pool.validatorSet().VotingPower()
-		state, err := initState(pool)
-		require.NoError(t, err)
-		senders := make([]NodeID, 0)
-		for nodeId := range votingPower {
-			senders = append(senders, nodeId)
-		}
-		assert.Equal(t, c.weight, state.calculateVotingPower(senders))
-	}
-}
-
 func TestState_MaxFaultyVotingPower_MixedVotingPower(t *testing.T) {
 	cases := []struct {
 		votingPower    map[NodeID]uint64
 		maxFaultyNodes uint64
 	}{
-		// {map[NodeID]uint64{"A": 0, "B": 0, "C": 0}, 0},
 		{map[NodeID]uint64{"A": 5, "B": 5, "C": 6}, 5},
 		{map[NodeID]uint64{"A": 5, "B": 5, "C": 5, "D": 5}, 6},
 		{map[NodeID]uint64{"A": 50, "B": 25, "C": 10, "D": 15}, 33},
@@ -392,30 +367,6 @@ func TestState_QuorumSize_MixedVotingPower(t *testing.T) {
 		state, err := initState(pool, c.votingPower)
 		require.NoError(t, err)
 		assert.Equal(t, c.quorumSize, state.getQuorumSize())
-	}
-}
-
-func TestState_CalculateWeight_MixedVotingPower(t *testing.T) {
-	cases := []struct {
-		votingPower map[NodeID]uint64
-		quorumSize  uint64
-	}{
-		{map[NodeID]uint64{"A": 5, "B": 5, "C": 5, "D": 5}, 20},
-		{map[NodeID]uint64{"A": 5, "B": 5, "C": 6}, 16},
-		{map[NodeID]uint64{"A": 50, "B": 25, "C": 10, "D": 15}, 100},
-	}
-	for _, c := range cases {
-		pool := newTesterAccountPool()
-		pool.add(getValidatorIds(c.votingPower)...)
-		state, err := initState(pool, c.votingPower)
-		require.NoError(t, err)
-		senders := make([]NodeID, len(c.votingPower))
-		i := 0
-		for nodeId := range c.votingPower {
-			senders[i] = nodeId
-			i++
-		}
-		assert.Equal(t, c.quorumSize, state.calculateVotingPower(senders))
 	}
 }
 

--- a/state_test.go
+++ b/state_test.go
@@ -152,18 +152,18 @@ func TestState_AddRoundMessage(t *testing.T) {
 	s := newState()
 	s.validators = newMockValidatorSet([]string{"A", "B"})
 
-	roundMessageSize := s.AddRoundMessage(createMessage("A", MessageReq_Commit, 0))
+	roundMessageSize := s.addRoundChangeMsg(createMessage("A", MessageReq_Commit, 0))
 	assert.Equal(t, 0, roundMessageSize)
 	assert.Equal(t, 0, len(s.roundMessages))
 
-	s.AddRoundMessage(createMessage("A", MessageReq_RoundChange, 0))
-	s.AddRoundMessage(createMessage("A", MessageReq_RoundChange, 1))
-	s.AddRoundMessage(createMessage("A", MessageReq_RoundChange, 2))
+	s.addRoundChangeMsg(createMessage("A", MessageReq_RoundChange, 0))
+	s.addRoundChangeMsg(createMessage("A", MessageReq_RoundChange, 1))
+	s.addRoundChangeMsg(createMessage("A", MessageReq_RoundChange, 2))
 
-	roundMessageSize = s.AddRoundMessage(createMessage("B", MessageReq_RoundChange, 2))
+	roundMessageSize = s.addRoundChangeMsg(createMessage("B", MessageReq_RoundChange, 2))
 	assert.Equal(t, 2, roundMessageSize)
 
-	s.AddRoundMessage(createMessage("B", MessageReq_RoundChange, 3))
+	s.addRoundChangeMsg(createMessage("B", MessageReq_RoundChange, 3))
 	assert.Equal(t, 4, len(s.roundMessages))
 
 	assert.Empty(t, s.prepared)
@@ -175,11 +175,11 @@ func TestState_addPrepared(t *testing.T) {
 	validatorIds := []string{"A", "B"}
 	s.validators = newMockValidatorSet(validatorIds)
 
-	s.addPrepared(createMessage("A", MessageReq_Commit))
+	s.addPrepareMsg(createMessage("A", MessageReq_Commit))
 	assert.Equal(t, 0, len(s.prepared))
 
-	s.addPrepared(createMessage("A", MessageReq_Prepare))
-	s.addPrepared(createMessage("B", MessageReq_Prepare))
+	s.addPrepareMsg(createMessage("A", MessageReq_Prepare))
+	s.addPrepareMsg(createMessage("B", MessageReq_Prepare))
 
 	assert.Equal(t, len(validatorIds), len(s.prepared))
 	assert.Empty(t, s.committed)
@@ -191,11 +191,11 @@ func TestState_addCommitted(t *testing.T) {
 	validatorIds := []string{"A", "B"}
 	s.validators = newMockValidatorSet(validatorIds)
 
-	s.addCommitted(createMessage("A", MessageReq_Prepare))
+	s.addCommitMsg(createMessage("A", MessageReq_Prepare))
 	assert.Empty(t, 0, s.committed)
 
-	s.addCommitted(createMessage("A", MessageReq_Commit))
-	s.addCommitted(createMessage("B", MessageReq_Commit))
+	s.addCommitMsg(createMessage("A", MessageReq_Commit))
+	s.addCommitMsg(createMessage("B", MessageReq_Commit))
 
 	assert.Equal(t, len(validatorIds), len(s.committed))
 	assert.Empty(t, s.prepared)
@@ -239,9 +239,9 @@ func TestState_getCommittedSeals(t *testing.T) {
 	s := newState()
 	s.validators = pool.validatorSet()
 
-	s.addCommitted(createMessage("A", MessageReq_Commit))
-	s.addCommitted(createMessage("B", MessageReq_Commit))
-	s.addCommitted(createMessage("C", MessageReq_Commit))
+	s.addCommitMsg(createMessage("A", MessageReq_Commit))
+	s.addCommitMsg(createMessage("B", MessageReq_Commit))
+	s.addCommitMsg(createMessage("C", MessageReq_Commit))
 	committedSeals := s.getCommittedSeals()
 
 	assert.Len(t, committedSeals, 3)
@@ -356,7 +356,7 @@ func TestState_CalculateWeight_EqualVotingPower(t *testing.T) {
 		for nodeId := range votingPower {
 			senders = append(senders, nodeId)
 		}
-		assert.Equal(t, c.weight, state.CalculateVotingPower(senders))
+		assert.Equal(t, c.weight, state.calculateVotingPower(senders))
 	}
 }
 
@@ -417,7 +417,7 @@ func TestState_CalculateWeight_MixedVotingPower(t *testing.T) {
 			senders[i] = nodeId
 			i++
 		}
-		assert.Equal(t, c.quorumSize, state.CalculateVotingPower(senders))
+		assert.Equal(t, c.quorumSize, state.calculateVotingPower(senders))
 	}
 }
 

--- a/test_helpers.go
+++ b/test_helpers.go
@@ -79,8 +79,8 @@ func (v *ValStringStub) VotingPower() map[NodeID]uint64 {
 	return v.VotingPowerMap
 }
 
-// CreateEqualWeightValidatorsMap is a helper function which creates map with same weight for every validator id in the provided slice
-func CreateEqualWeightValidatorsMap(validatorIds []NodeID) map[NodeID]uint64 {
+// CreateEqualVotingPowerMap is a helper function which creates map with same weight for every validator id in the provided slice
+func CreateEqualVotingPowerMap(validatorIds []NodeID) map[NodeID]uint64 {
 	weightedValidators := make(map[NodeID]uint64, len(validatorIds))
 	for _, validatorId := range validatorIds {
 		weightedValidators[validatorId] = 1


### PR DESCRIPTION
Instead of calculating accumulated voting power each time a message is retrieved from the queue, it is now cached and updated on each message retrieval.