### PR TITLE
Liveness fix (introduce relocking concept)

### DIFF
--- a/consensus_cfg.go
+++ b/consensus_cfg.go
@@ -58,6 +58,12 @@ func WithVotingPower(vp map[NodeID]uint64) ConfigOption {
 	}
 }
 
+func WithLivenessFixes(isEnabled bool) ConfigOption {
+	return func(c *Config) {
+		c.IsLivenessFixEnabled = isEnabled
+	}
+}
+
 type Config struct {
 	// ProposalTimeout is the time to wait for the proposal
 	// from the validator. It defaults to Timeout
@@ -82,6 +88,8 @@ type Config struct {
 	StatsCallback StatsCallback
 
 	VotingPower map[NodeID]uint64
+
+	IsLivenessFixEnabled bool
 }
 
 func DefaultConfig() *Config {

--- a/consensus_pbft.go
+++ b/consensus_pbft.go
@@ -305,13 +305,14 @@ func (p *Pbft) runAcceptState(ctx context.Context) { // start new round
 
 		// send the preprepare message
 		p.sendPreprepareMsg()
+		// send the prepare message since we are ready to move the state
+		p.sendPrepareMsg()
 
-		if !p.state.IsLocked() {
-			// send the prepare message since we are ready to move the state
-			p.sendPrepareMsg()
-		} else {
-			// proposer node is already locked to the same proposal => fast-track and send commit message straight away
-			p.sendCommitMsg()
+		if p.config.IsLivenessFixEnabled {
+			if p.state.IsLocked() {
+				// proposer node is already locked to the same proposal => fast-track and send commit message straight away
+				p.sendCommitMsg()
+			}
 		}
 
 		// move to validation state for new prepare messages
@@ -354,7 +355,10 @@ func (p *Pbft) runAcceptState(ctx context.Context) { // start new round
 		if p.state.IsLocked() {
 			// the state is locked, we need to receive the same proposal
 			if p.state.proposal.Equal(proposal) {
-				// fast-track (send a commit message) and wait for validations
+				if p.config.IsLivenessFixEnabled {
+					// fast-track (send prepare and commit message) and wait for validations
+					p.sendPrepareMsg()
+				}
 				p.sendCommitMsg()
 				p.setState(ValidateState)
 			} else {
@@ -365,6 +369,7 @@ func (p *Pbft) runAcceptState(ctx context.Context) { // start new round
 					p.logger.Printf("[%s] Relocking to a propsal: %v", p.validator.NodeID(), proposal.Data)
 					p.state.proposal = proposal
 					p.state.lock(msg.View.Round)
+					p.sendPrepareMsg()
 					p.sendCommitMsg()
 					p.setState(ValidateState)
 				} else {
@@ -385,6 +390,10 @@ func (p *Pbft) runAcceptState(ctx context.Context) { // start new round
 //
 // Returns true if there are at least 2*F commit messages in the queue (meaning that node should relock to the given proposal), otherwise false.
 func (p *Pbft) shouldRelock(preprepareMsg *MessageReq) bool {
+	if !p.config.IsLivenessFixEnabled {
+		return false
+	}
+
 	// shouldRelock is invoked when transferred from RoundChangeState to AcceptState.
 	// Since it contains specific logic for commit messages counting, this checkup is introduced.
 	if !p.IsState(AcceptState) {
@@ -435,8 +444,12 @@ func (p *Pbft) runValidateState(ctx context.Context) { // start new round
 	sendCommit := func(span trace.Span) {
 		// at this point either we have enough prepare messages
 		// or commit messages so we can lock the proposal
-		if !p.state.IsLocked() {
-			// invoke lock only at initial round when locking occurred
+		if p.config.IsLivenessFixEnabled {
+			if !p.state.IsLocked() {
+				// invoke lock only at initial round when locking occurred
+				p.state.lock(p.state.view.Round)
+			}
+		} else {
 			p.state.lock(p.state.view.Round)
 		}
 

--- a/consensus_pbft.go
+++ b/consensus_pbft.go
@@ -306,8 +306,13 @@ func (p *Pbft) runAcceptState(ctx context.Context) { // start new round
 		// send the preprepare message
 		p.sendPreprepareMsg()
 
-		// send the prepare message since we are ready to move the state
-		p.sendPrepareMsg()
+		if !p.state.IsLocked() {
+			// send the prepare message since we are ready to move the state
+			p.sendPrepareMsg()
+		} else {
+			// proposer node is already locked to the same proposal => fast-track and send commit message straight away
+			p.sendCommitMsg()
+		}
 
 		// move to validation state for new prepare messages
 		p.setState(ValidateState)
@@ -349,11 +354,22 @@ func (p *Pbft) runAcceptState(ctx context.Context) { // start new round
 		if p.state.IsLocked() {
 			// the state is locked, we need to receive the same proposal
 			if p.state.proposal.Equal(proposal) {
-				// fast-track and send a commit message and wait for validations
+				// fast-track (send a commit message) and wait for validations
 				p.sendCommitMsg()
 				p.setState(ValidateState)
 			} else {
-				p.handleStateErr(errIncorrectLockedProposal)
+				// Relocking logic:
+				// - we have locked different proposal in a round older than the given PRE-PREPARE message belongs to
+				// - there are enough COMMIT messages for more recent round and given (PRE-PREPARE) proposal, so we should relock to the given proposal instead and vote for it.
+				if p.shouldRelock(msg) {
+					p.logger.Printf("[%s] Relocking to a propsal: %v", p.validator.NodeID(), proposal.Data)
+					p.state.proposal = proposal
+					p.state.lock(msg.View.Round)
+					p.sendCommitMsg()
+					p.setState(ValidateState)
+				} else {
+					p.handleStateErr(errIncorrectLockedProposal)
+				}
 			}
 		} else {
 			p.state.proposal = proposal
@@ -361,6 +377,47 @@ func (p *Pbft) runAcceptState(ctx context.Context) { // start new round
 			p.setState(ValidateState)
 		}
 	}
+}
+
+// shouldRelock checks whether there are at least 2*F (F denotes maximum number of faulty nodes)
+// commit messages for the current sequence and the current round in the validate state message queue.
+// It is invoked in a case a non-proposer node got locked on some previous rounds on different proposal than the given one.
+//
+// Returns true if there are at least 2*F commit messages in the queue (meaning that node should relock to the given proposal), otherwise false.
+func (p *Pbft) shouldRelock(preprepareMsg *MessageReq) bool {
+	// shouldRelock is invoked when transferred from RoundChangeState to AcceptState.
+	// Since it contains specific logic for commit messages counting, this checkup is introduced.
+	if !p.IsState(AcceptState) {
+		return false
+	}
+
+	if *p.state.lockedRound > preprepareMsg.View.Round {
+		// proposal must be locked in the some round which is older than the PRE-PREPARE message is from
+		return false
+	}
+
+	commitMessagesCount := 0
+	err := p.msgQueue.iterator(msgToState(MessageReq_Commit), func(currentMsg *MessageReq) {
+		// Logical condition below decomposes to the following.
+		// Count messages that have following properties:
+		// 1. message is from the current round (and sequence),
+		// 2. COMMIT message type,
+		// 3. message round is more recent than the one proposal got locked,
+		// 4. proposal hash of the COMMIT message is the same as the one from PRE-PREPARE message.
+		if cmpView(p.state.view, currentMsg.View) == 0 &&
+			currentMsg.Type == MessageReq_Commit &&
+			*p.state.lockedRound < currentMsg.View.Round &&
+			bytes.Equal(preprepareMsg.Hash, currentMsg.Hash) {
+			commitMessagesCount++
+		}
+	})
+	if err != nil {
+		p.logger.Printf("[ERROR] Iterator failed. Reason: %v", err)
+		return false
+	}
+
+	// 2*F Commit messages (+1 commit message will correspond to the current non-proposer node COMMIT message)
+	return commitMessagesCount >= p.state.NumValid()
 }
 
 // runValidateState implements the Validate state loop.
@@ -378,7 +435,10 @@ func (p *Pbft) runValidateState(ctx context.Context) { // start new round
 	sendCommit := func(span trace.Span) {
 		// at this point either we have enough prepare messages
 		// or commit messages so we can lock the proposal
-		p.state.lock()
+		if !p.state.IsLocked() {
+			// invoke lock only at initial round when locking occurred
+			p.state.lock(p.state.view.Round)
+		}
 
 		if !hasCommitted {
 			// send the commit message
@@ -418,7 +478,7 @@ func (p *Pbft) runValidateState(ctx context.Context) { // start new round
 			}
 			p.state.addCommitted(msg)
 		default:
-			panic(fmt.Errorf("BUG: Unexpected message type: %s in %s", msg.Type, p.getState()))
+			panic(fmt.Errorf("BUG: Unexpected message type: %s in %s from node %s", msg.Type, p.getState(), msg.From))
 		}
 
 		//if voting power is disabled - count number of votes
@@ -512,6 +572,9 @@ func (p *Pbft) runCommitState(ctx context.Context) {
 
 	committedSeals := p.state.getCommittedSeals()
 	proposal := p.state.proposal.Copy()
+
+	// TODO: [Liveness] Should unlock happen only when insertion fails (it is like that in IBFT, although it doesn't make much sense)?
+	// https://github.com/ConsenSys/quorum/blob/master/consensus/istanbul/ibft/core/core.go#L177
 
 	// at this point either if it works or not we need to unlock the state
 	// to allow for other proposals to be produced if it insertion fails
@@ -760,7 +823,7 @@ func (p *Pbft) setState(s State) {
 
 // IsLocked returns if the current proposal is locked
 func (p *Pbft) IsLocked() bool {
-	return atomic.LoadUint64(&p.state.locked) == 1
+	return p.state.IsLocked()
 }
 
 // GetProposal returns current proposal in the pbft

--- a/e2e/cluster.go
+++ b/e2e/cluster.go
@@ -35,6 +35,7 @@ type ClusterConfig struct {
 	TransportHandler      transport.Handler
 	RoundTimeout          pbft.RoundTimeout
 	CreateBackend         CreateBackend
+	LivenessFixEnabled    bool
 }
 
 type Cluster struct {

--- a/e2e/e2e_partition_test.go
+++ b/e2e/e2e_partition_test.go
@@ -77,9 +77,10 @@ func TestE2E_Partition_LivenessIssue_Case1_FiveNodes_OneFaulty(t *testing.T) {
 	transport.WithFlowMap(flowMap).WithGossipHandler(livenessGossipHandler)
 
 	config := &ClusterConfig{
-		Count:  5,
-		Name:   "liveness_issue",
-		Prefix: "A",
+		Count:              5,
+		Name:               "liveness_issue",
+		Prefix:             "A",
+		LivenessFixEnabled: true,
 	}
 
 	c := NewPBFTCluster(t, config, transport)
@@ -179,9 +180,10 @@ func TestE2E_Partition_LivenessIssue_Case2_SixNodes_OneFaulty(t *testing.T) {
 	transport.WithFlowMap(flowMap).WithGossipHandler(livenessGossipHandler)
 
 	config := &ClusterConfig{
-		Count:  6,
-		Name:   "liveness_issue",
-		Prefix: "A",
+		Count:              6,
+		Name:               "liveness_issue",
+		Prefix:             "A",
+		LivenessFixEnabled: true,
 	}
 
 	c := NewPBFTCluster(t, config, transport)
@@ -224,10 +226,11 @@ func TestE2E_Network_Stuck_Locked_Node_Dropped(t *testing.T) {
 	transport := transport.NewGenericGossip()
 
 	config := &ClusterConfig{
-		Count:        4,
-		Name:         "liveness_issue",
-		Prefix:       "A",
-		RoundTimeout: helper.GetPredefinedTimeout(2 * time.Second),
+		Count:              4,
+		Name:               "liveness_issue",
+		Prefix:             "A",
+		RoundTimeout:       helper.GetPredefinedTimeout(2 * time.Second),
+		LivenessFixEnabled: true,
 	}
 
 	c := NewPBFTCluster(t, config, transport)
@@ -262,8 +265,7 @@ func TestE2E_Network_Stuck_Locked_Node_Dropped(t *testing.T) {
 			t.Logf("Node %v, running: %v, isProposalLocked: %v, no proposal set\n", n.name, n.IsRunning(), n.pbft.IsLocked())
 		}
 	}
-	// TODO: Temporary assertion until liveness issue is fixed
-	assert.Error(t, err)
+	assert.NoError(t, err)
 }
 
 func TestE2E_Partition_OneMajority(t *testing.T) {

--- a/e2e/e2e_partition_test.go
+++ b/e2e/e2e_partition_test.go
@@ -54,14 +54,15 @@ func TestE2E_Partition_LivenessIssue_Case1_FiveNodes_OneFaulty(t *testing.T) {
 	transport := transport.NewGenericGossip()
 	// If livenessGossipHandler returns false, message should not be transported.
 	livenessGossipHandler := func(senderId, receiverId pbft.NodeID, msg *pbft.MessageReq) bool {
+		if msg.View.Round <= 1 && msg.Type == pbft.MessageReq_Commit {
+			// Cut all the commit messages gossiping for round 0 and 1
+			return false
+		}
+
 		if msg.View.Round > 1 || msg.View.Sequence > 2 {
 			// Faulty node is unresponsive after round 1, and all the other nodes are gossiping all the messages.
 			return senderId != faultyNodeId && receiverId != faultyNodeId
 		} else {
-			if msg.View.Round <= 1 && msg.Type == pbft.MessageReq_Commit {
-				// Cut all the commit messages gossiping for round 0 and 1
-				return false
-			}
 			if msg.View.Round == 1 && senderId == faultyNodeId &&
 				(msg.Type == pbft.MessageReq_RoundChange || msg.Type == pbft.MessageReq_Commit) {
 				// Case where we are in round 1 and 2 different nodes will lock the proposal
@@ -85,7 +86,7 @@ func TestE2E_Partition_LivenessIssue_Case1_FiveNodes_OneFaulty(t *testing.T) {
 	c.Start()
 	defer c.Stop()
 
-	err := c.WaitForHeight(3, 1*time.Minute, []string{"A_0", "A_2", "A_3", "A_4"})
+	err := c.WaitForHeight(3, 5*time.Minute, []string{"A_0", "A_2", "A_3", "A_4"})
 
 	if err != nil {
 		// log to check what is the end state
@@ -99,8 +100,7 @@ func TestE2E_Partition_LivenessIssue_Case1_FiveNodes_OneFaulty(t *testing.T) {
 		}
 	}
 
-	// TODO: Temporary assertion until liveness issue is resolved (after fix is merged we need to revert back to assert.NoError(t, err))
-	assert.Error(t, err)
+	assert.NoError(t, err)
 }
 
 // Test proves existence of liveness issues which is described in
@@ -188,7 +188,7 @@ func TestE2E_Partition_LivenessIssue_Case2_SixNodes_OneFaulty(t *testing.T) {
 	c.Start()
 	defer c.Stop()
 
-	err := c.WaitForHeight(3, 1*time.Minute, []string{"A_0", "A_1", "A_3", "A_4", "A_5"})
+	err := c.WaitForHeight(3, 5*time.Minute, []string{"A_0", "A_1", "A_3", "A_4", "A_5"})
 
 	if err != nil {
 		// log to check what is the end state
@@ -202,8 +202,7 @@ func TestE2E_Partition_LivenessIssue_Case2_SixNodes_OneFaulty(t *testing.T) {
 		}
 	}
 
-	// TODO: Temporary assertion until liveness issue is resolved (after fix is merged we need to revert back to assert.NoError(t, err))
-	assert.Error(t, err)
+	assert.NoError(t, err)
 }
 
 // TestE2E_Network_Stuck_Locked_Node_Dropped is a test that creates a situation with no consensus

--- a/e2e/node.go
+++ b/e2e/node.go
@@ -41,6 +41,7 @@ func newPBFTNode(name string, clusterConfig *ClusterConfig, nodes []string, trac
 		pbft.WithLogger(log.New(loggerOutput, "", log.LstdFlags)),
 		pbft.WithNotifier(clusterConfig.ReplayMessageNotifier),
 		pbft.WithRoundTimeout(clusterConfig.RoundTimeout),
+		pbft.WithLivenessFixes(clusterConfig.LivenessFixEnabled),
 	)
 
 	if clusterConfig.TransportHandler != nil {

--- a/msg_queue.go
+++ b/msg_queue.go
@@ -2,6 +2,7 @@ package pbft
 
 import (
 	"container/heap"
+	"fmt"
 	"sync"
 )
 
@@ -92,6 +93,20 @@ func (m *msgQueue) getQueue(st State) *msgQueueImpl {
 	}
 }
 
+// iterator fetches corresponding message queue based on pbft state and invokes iteratorLocked method against it.
+func (m *msgQueue) iterator(pbftState State, iterateHandler func(*MessageReq)) error {
+	m.queueLock.Lock()
+	defer m.queueLock.Unlock()
+
+	queueImpl := m.getQueue(pbftState)
+	if queueImpl == nil {
+		return fmt.Errorf("failed to resolve message queue for %s message type", MessageReq_Commit)
+	}
+
+	queueImpl.iteratorLocked(iterateHandler)
+	return nil
+}
+
 // newMsgQueue creates a new message queue structure
 func newMsgQueue() *msgQueue {
 	return &msgQueue{
@@ -175,6 +190,16 @@ func (m *msgQueueImpl) Pop() interface{} {
 	old[n-1] = nil
 	*m = old[0 : n-1]
 	return item
+}
+
+// iteratorLocked is iterator with custom handler which contains some arbitrary logic.
+// It is assumed that method is invoked within the lock.
+func (m *msgQueueImpl) iteratorLocked(iterateHandler func(*MessageReq)) {
+	for _, msg := range *m {
+		if iterateHandler != nil {
+			iterateHandler(msg.Copy())
+		}
+	}
 }
 
 // cmpView compares two proto views.

--- a/state_test.go
+++ b/state_test.go
@@ -293,7 +293,8 @@ func TestState_Lock_Unlock(t *testing.T) {
 		Data: proposalData,
 		Time: time.Now(),
 	}
-	s.lock()
+
+	s.lock(0)
 	assert.True(t, s.IsLocked())
 	assert.NotNil(t, s.proposal)
 


### PR DESCRIPTION
This PR is solution proposal for liveness issue by introducing a re-locking concept.
Re-locking enables that node which has locked some proposal in some of the previous rounds, locks a new one if it witnesses enough (2 * F, where F denotes max count of faulty nodes in order to have Byzantine fault tolerant system) COMMIT messages from the most recent round, which have the same proposal as the one sent the current proposer via a PRE-PREPARE message. If that is the case, then validator node rejects its locked proposal and immediately locks the one from PRE-PREPARE messages and votes for it by sending COMMIT message.
In order to track a round when the given node is initially locked, a lockedRound *uint64 field is introduced to the state struct. When lockedRound is set to nil, it denotes that no proposal is locked (yet).