### PR TITLE
Fix order in validate

### DIFF
--- a/consensus_pbft.go
+++ b/consensus_pbft.go
@@ -339,6 +339,11 @@ func (p *Pbft) runAcceptState(ctx context.Context) { // start new round
 			Data: msg.Proposal,
 			Hash: msg.Hash,
 		}
+		if p.state.IsLocked() && !p.state.proposal.Equal(proposal) {
+			p.handleStateErr(errIncorrectLockedProposal)
+			return
+		}
+
 		if err := p.backend.Validate(proposal); err != nil {
 			p.logger.Printf("[ERROR] failed to validate proposal. Error message: %v", err)
 			p.setState(RoundChangeState)
@@ -346,14 +351,9 @@ func (p *Pbft) runAcceptState(ctx context.Context) { // start new round
 		}
 
 		if p.state.IsLocked() {
-			// the state is locked, we need to receive the same proposal
-			if p.state.proposal.Equal(proposal) {
-				// fast-track and send a commit message and wait for validations
-				p.sendCommitMsg()
-				p.setState(ValidateState)
-			} else {
-				p.handleStateErr(errIncorrectLockedProposal)
-			}
+			// fast-track and send a commit message and wait for validations
+			p.sendCommitMsg()
+			p.setState(ValidateState)
 		} else {
 			p.state.proposal = proposal
 			p.sendPrepareMsg()


### PR DESCRIPTION
This PR changes the order in the validation of preprepare proposals. Before, the `Backend.Validate` function would be called before checking if the locked proposal was valid. Thus, the internal state of the backend could be changed for a state that was invalid.