### PR TITLE
Move unlocking when setting sequence

### DIFF
--- a/consensus_pbft.go
+++ b/consensus_pbft.go
@@ -230,6 +230,7 @@ func (p *Pbft) setSequence(sequence uint64) {
 		Sequence: sequence,
 	}
 	p.setRound(0)
+	p.state.unlock()
 }
 
 func (p *Pbft) setRound(round uint64) {
@@ -498,10 +499,6 @@ func (p *Pbft) runCommitState(ctx context.Context) {
 
 	committedSeals := p.state.getCommittedSeals()
 	proposal := p.state.proposal.Copy()
-
-	// at this point either if it works or not we need to unlock the state
-	// to allow for other proposals to be produced if it insertion fails
-	p.state.unlock()
 
 	pp := &SealedProposal{
 		Proposal:       proposal,

--- a/consensus_test.go
+++ b/consensus_test.go
@@ -708,6 +708,7 @@ func TestPbft_Run(t *testing.T) {
 		commitMsgsVotingPower:  1,
 		commitMsgs:             1,
 		outgoing:               3,
+		locked:                 true,
 	})
 }
 

--- a/state.go
+++ b/state.go
@@ -157,7 +157,6 @@ func (s *state) lock() {
 
 func (s *state) unlock() {
 	s.proposal = nil
-
 	atomic.StoreUint64(&s.locked, 0)
 }
 


### PR DESCRIPTION
If node gets out of sync at some point and it previously locked some proposal, it won't unlock it even if it manages to sync up with network and proceed to the current sequence.

Therefore we are moving unlocking logic from the `runCommitState` to `setSequence` function (which is being executed at the beginning of the consensus algorithm).